### PR TITLE
Added local/server time and next tick tickers

### DIFF
--- a/app/resources/assets/js/app.js
+++ b/app/resources/assets/js/app.js
@@ -1,3 +1,6 @@
 'use strict';
 
 require('./bootstrap');
+
+const ticker = require('./ticker');
+ticker();

--- a/app/resources/assets/js/ticker.js
+++ b/app/resources/assets/js/ticker.js
@@ -1,0 +1,55 @@
+
+// todo: there's probably a more elegant way to implement this :)
+
+function ticker() {
+    tick();
+    setInterval(tick, 1000);
+}
+
+function tick() {
+    const now = new Date();
+    const nextHour = new Date();
+    nextHour.setHours(now.getHours() + 1);
+    nextHour.setMinutes(0);
+    nextHour.setSeconds(0);
+    const el = document.getElementById('tickers');
+    if (el != null) {
+        el.getElementsByClassName('ticker-local')[0].innerHTML = hms(now);
+        el.getElementsByClassName('ticker-server')[0].innerHTML = hms(utc(now));
+        el.getElementsByClassName('ticker-next-tick')[0].innerHTML = hms(nextHour - now);
+    }
+}
+
+function hms(value) {
+    let hours = 0;
+    let minutes = 0;
+    let seconds = 0;
+    if (value instanceof Date) {
+        hours = value.getHours();
+        minutes = value.getMinutes();
+        seconds = value.getSeconds();
+    } else if (typeof value == 'number') {
+        value = parseInt(value) / 1000;
+        seconds = value % 60;
+        minutes = (value - seconds) / 60;
+        hours = (value - (minutes * 60) - seconds) / 60;
+    }
+    return pad(hours) + ':' + pad(minutes) + ':' + pad(seconds);
+}
+
+function pad(value) {
+    return ('00' + value).slice(-2);
+}
+
+function utc(date) {
+    return new Date(
+        date.getUTCFullYear(),
+        date.getUTCMonth(),
+        date.getUTCDate(),
+        date.getUTCHours(),
+        date.getUTCMinutes(),
+        date.getUTCSeconds()
+    )
+}
+
+module.exports = ticker;

--- a/app/resources/views/layouts/master.blade.php
+++ b/app/resources/views/layouts/master.blade.php
@@ -35,6 +35,9 @@
                             @yield('page-subheader')
                         </small>
                     @endif
+
+                    @include('partials.tickers')
+
                 </h1>
                 {{--<ol class="breadcrumb">
                     <li><a href="#"><i class="fa fa-dashboard"></i> Home</a></li>

--- a/app/resources/views/partials/tickers.blade.php
+++ b/app/resources/views/partials/tickers.blade.php
@@ -1,0 +1,11 @@
+<div id="tickers" class="pull-right">
+    <span class="badge hidden-xs">
+        local: <span class="ticker-local">00:00:00</span>
+    </span>
+    <span class="badge">
+        server: <span class="ticker-server">00:00:00</span>
+    </span>
+    <span class="badge">
+        next tick: <span class="ticker-next-tick">00:00:00</span>
+    </span>
+</div>


### PR DESCRIPTION
This change should provide tickers for your local time, the server time (UTC), and the time remaining before the next game tick (time until the next hour). The tickers will "tick" every second with the updated times.

Note that you'll need to rebuild your web assets (@WaveHack, I'm sure you already know :P).

Large displays:
![image](https://user-images.githubusercontent.com/2818916/27267447-713fc5d0-5476-11e7-8db9-1646ffb15b01.png)

Small displays (mobile):
![image](https://user-images.githubusercontent.com/2818916/27267457-83e11a4a-5476-11e7-8541-542583e4fa3f.png)

Resolves #67