### PR TITLE
Pluralizing strings in info boxes. Fix WaveHack/OpenDominion#91

### DIFF
--- a/app/resources/views/pages/dominion/bank.blade.php
+++ b/app/resources/views/pages/dominion/bank.blade.php
@@ -96,7 +96,7 @@
                 <div class="box-body">
                     <p>The National Bank allows you to exchange resources with the empire. Exchanging resources processes <b>instantly</b>.</p>
                     <p>Platinum, lumber and ore trade 2 for 1.<br>Gems trade 1:2 platinum, lumber or ore.<br>Food sells for 4 platinum, lumber or ore, or 1 gem.</p>
-                    <p>You have {{ number_format($selectedDominion->resource_platinum) }} platinum, {{ number_format($selectedDominion->resource_lumber) }} lumber, {{ number_format($selectedDominion->resource_ore) }} ore and {{ number_format($selectedDominion->resource_gems) }} gems.</p>
+                    <p>You have {{ number_format($selectedDominion->resource_platinum) }} platinum, {{ number_format($selectedDominion->resource_lumber) }} lumber, {{ number_format($selectedDominion->resource_ore) }} ore and {{ number_format($selectedDominion->resource_gems) }} {{ str_plural('gem', $selectedDominion->resource_gems) }}.</p>
                 </div>
             </div>
         </div>

--- a/app/resources/views/pages/dominion/construction.blade.php
+++ b/app/resources/views/pages/dominion/construction.blade.php
@@ -68,7 +68,7 @@
                     <div class="box-footer">
                         <button type="submit" class="btn btn-primary" {{ $selectedDominion->isLocked() ? 'disabled' : null }}>Build</button>
                         <div class="pull-right">
-                            You have {{ number_format($landCalculator->getTotalLand($selectedDominion)) }} acres of land.
+                            You have {{ number_format($landCalculator->getTotalLand($selectedDominion)) }} {{ str_plural('acre', $landCalculator->getTotalLand($selectedDominion)) }} of land.
                         </div>
                     </div>
                 </form>
@@ -84,8 +84,8 @@
                 <div class="box-body">
                     <p>Construction will let you construct additional buildings and will take <b>12 hours</b> to process.</p>
                     <p>Construction per building will come at a cost of 1 acre of barren land of the building type, {{ number_format($constructionCalculator->getPlatinumCost($selectedDominion)) }} platinum and {{ number_format($constructionCalculator->getLumberCost($selectedDominion)) }} lumber.</p>
-                    <p>You have {{ number_format($landCalculator->getTotalBarrenLand($selectedDominion)) }} acres of barren land, {{ number_format($selectedDominion->resource_platinum) }} platinum and {{ number_format($selectedDominion->resource_lumber) }} lumber.</p>
-                    <p>You can afford to construct <b>{{ number_format($constructionCalculator->getMaxAfford($selectedDominion)) }} buildings</b> at that rate.</p>
+                    <p>You have {{ number_format($landCalculator->getTotalBarrenLand($selectedDominion)) }} {{ str_plural('acre', $landCalculator->getTotalBarrenLand($selectedDominion)) }} of barren land, {{ number_format($selectedDominion->resource_platinum) }} platinum and {{ number_format($selectedDominion->resource_lumber) }} lumber.</p>
+                    <p>You can afford to construct <b>{{ number_format($constructionCalculator->getMaxAfford($selectedDominion)) }} {{ str_plural('building', $constructionCalculator->getMaxAfford($selectedDominion)) }}</b> at that rate.</p>
                     <p>You may also <a href="{{ route('dominion.destroy') }}">destroy buildings</a> if you wish.</p>
                 </div>
             </div>

--- a/app/resources/views/pages/dominion/council/index.blade.php
+++ b/app/resources/views/pages/dominion/council/index.blade.php
@@ -80,7 +80,7 @@
                 <div class="box-body">
                     <p>The council is where you can communicate with the rest of your realm. Only you and other dominions inside your realm can view and post in here.</p>
                     {{--<p>Your realm monarch is X and has the power to moderate the council board.</p>--}}
-                    <p>There {{ ($councilThreads->count() === 1) ? 'is' : 'are' }} {{ number_format($councilThreads->count()) }} {{ str_plural('thread', $councilThreads->count()) }} {{--and {{ number_format($councilThreads->posts->count()) }} posts --}}in the council.</p>
+                    <p>There {{ ($councilThreads->count() === 1) ? 'is' : 'are' }} {{ number_format($councilThreads->count()) }} {{ str_plural('thread', $councilThreads->count()) }} {{--and {{ number_format($councilThreads->posts->count()) }} {{ str_plural('post', $councilThreads->posts->count()) }} --}}in the council.</p>
                 </div>
             </div>
         </div>

--- a/app/resources/views/pages/dominion/explore.blade.php
+++ b/app/resources/views/pages/dominion/explore.blade.php
@@ -68,9 +68,9 @@
                 </div>
                 <div class="box-body">
                     <p>Exploration will net you additional acres of barren land to construct buildings upon and will take <b>12 hours</b> to process.</p>
-                    <p>Exploration per acre of barren land will come at a cost of {{ number_format($explorationCalculator->getPlatinumCost($selectedDominion)) }} platinum and {{ number_format($explorationCalculator->getDrafteeCost($selectedDominion)) }} draftees.</p>
-                    <p>You have {{ number_format($selectedDominion->resource_platinum) }} platinum and {{ number_format($selectedDominion->military_draftees) }} draftees.</p>
-                    <p>You can afford to explore for <b>{{ number_format($explorationCalculator->getMaxAfford($selectedDominion)) }} acres of barren land</b> at that rate.</p>
+                    <p>Exploration per acre of barren land will come at a cost of {{ number_format($explorationCalculator->getPlatinumCost($selectedDominion)) }} platinum and {{ number_format($explorationCalculator->getDrafteeCost($selectedDominion)) }} {{ str_plural('draftee', $explorationCalculator->getDrafteeCost($selectedDominion)) }}.</p>
+                    <p>You have {{ number_format($selectedDominion->resource_platinum) }} platinum and {{ number_format($selectedDominion->military_draftees) }} {{ str_plural('draftee', $selectedDominion->military_draftees) }}.</p>
+                    <p>You can afford to explore for <b>{{ number_format($explorationCalculator->getMaxAfford($selectedDominion)) }} {{ str_plural('acre', $explorationCalculator->getMaxAfford($selectedDominion)) }} of barren land</b> at that rate.</p>
                 </div>
             </div>
         </div>

--- a/app/resources/views/pages/dominion/military.blade.php
+++ b/app/resources/views/pages/dominion/military.blade.php
@@ -81,8 +81,7 @@
                     <div class="box-footer">
                         <button type="submit" class="btn btn-primary" {{ $selectedDominion->isLocked() ? 'disabled' : null }}>Train</button>
                         <div class="pull-right">
-                            You have {{ number_format($selectedDominion->military_draftees) }} draftees available to
-                            train.
+                            You have {{ number_format($selectedDominion->military_draftees) }} {{ str_plural('draftee', $selectedDominion->military_draftees) }} available to train.
                         </div>
                     </div>
                 </form>
@@ -98,7 +97,7 @@
                 </div>
                 <div class="box-body">
                     <p>Here you can train your draftees into proper military units. Training units takes <b>12 hours</b> to process.</p>
-                    <p>You have {{ number_format($selectedDominion->resource_platinum) }} platinum, {{ number_format($selectedDominion->resource_ore) }} ore and {{ number_format($selectedDominion->military_draftees) }} draftees.</p>
+                    <p>You have {{ number_format($selectedDominion->resource_platinum) }} platinum, {{ number_format($selectedDominion->resource_ore) }} ore and {{ number_format($selectedDominion->military_draftees) }} {{ str_plural('draftee', $selectedDominion->military_draftees) }}.</p>
                     <p>You may also <a href="{{ route('dominion.military.release') }}">release your troops</a> if you wish.</p>
                 </div>
             </div>

--- a/app/resources/views/pages/dominion/realm.blade.php
+++ b/app/resources/views/pages/dominion/realm.blade.php
@@ -86,7 +86,7 @@
                 </div>
                 <div class="box-body">
                     <p>This is the realm <strong>{{ $realm->name }} (#{{ $realm->number }})</strong>.</p>
-                    <p>Its alignment is <strong>{{ $realm->alignment }}</strong>, it contains <strong>{{ $dominions->count() }}</strong> dominion(s) and its networth is <strong>{{ number_format($networthCalculator->getRealmNetworth($realm)) }}</strong>.</p>
+                    <p>Its alignment is <strong>{{ $realm->alignment }}</strong>, it contains <strong>{{ $dominions->count() }}</strong> {{ str_plural('dominion', $dominions->count()) }} and its networth is <strong>{{ number_format($networthCalculator->getRealmNetworth($realm)) }}</strong>.</p>
                     {{-- todo: change this to a table? --}}
                 </div>
                 @if (($prevRealm !== null) || ($nextRealm !== null))

--- a/app/resources/views/pages/dominion/rezone.blade.php
+++ b/app/resources/views/pages/dominion/rezone.blade.php
@@ -73,8 +73,8 @@
                 <div class="box-body">
                     <p>Land rezoning is the art of converting land of one type into another type. Land rezoning processes <b>instantly</b>.</p>
                     <p>Each acre of barren land being converted will come at a cost of: {{ $rezoningCalculator->getPlatinumCost($selectedDominion) }} platinum.</p>
-                    <p>You have {{ number_format($landCalculator->getTotalBarrenLand($selectedDominion)) }} acres of barren land and {{ number_format($selectedDominion->resource_platinum) }} platinum.</p>
-                    <p>You can afford to re-zone <b>{{ number_format($rezoningCalculator->getMaxAfford($selectedDominion)) }} acres of barren land</b> at that rate.</p>
+                    <p>You have {{ number_format($landCalculator->getTotalBarrenLand($selectedDominion)) }} {{ str_plural('acre', $landCalculator->getTotalBarrenLand($selectedDominion)) }} of barren land and {{ number_format($selectedDominion->resource_platinum) }} platinum.</p>
+                    <p>You can afford to re-zone <b>{{ number_format($rezoningCalculator->getMaxAfford($selectedDominion)) }} {{ str_plural('acre', $rezoningCalculator->getMaxAfford($selectedDominion)) }} of barren land</b> at that rate.</p>
                 </div>
             </div>
         </div>

--- a/app/resources/views/pages/dominion/status.blade.php
+++ b/app/resources/views/pages/dominion/status.blade.php
@@ -175,7 +175,7 @@
             @if ($dominionProtectionService->isUnderProtection($selectedDominion))
                 <div class="box box-warning">
                     <div class="box-body">
-                        <p>You are under a magical state of protection for <b>{{ number_format($dominionProtectionService->getUnderProtectionHoursLeft($selectedDominion), 2) }}</b> hours.</p>
+                        <p>You are under a magical state of protection for <b>{{ number_format($dominionProtectionService->getUnderProtectionHoursLeft($selectedDominion), 2) }}</b> {{ str_plural('hour', $dominionProtectionService->getUnderProtectionHoursLeft($selectedDominion)) }}.</p>
                         <p>During protection you cannot be attacked or attack other dominions. You can neither cast any offensive spells or engage in espionage.</p>
                         {{-- todo: remove line below once those things have been developed --}}
                         <p><i>You can't do that regardless yet because OpenDominion is still in development and those features haven't been built yet.</i></p>


### PR DESCRIPTION
This PR adds proper plural handling for strings in pages. It's using `str_plural` as suggested on #91. I believe I did that for all of them. Let me know if something is missing.