### PR TITLE
Replaced help text in lists by a tooltip. Using Bootstrap's tooltip.

### DIFF
--- a/app/resources/views/pages/dominion/construction.blade.php
+++ b/app/resources/views/pages/dominion/construction.blade.php
@@ -44,8 +44,8 @@
                                         <tr>
                                             <td>
                                                 {{ ucwords(str_replace('_', ' ', $buildingType)) }}
-                                                {!! $buildingHelper->getBuildingImplementedString($buildingType) !!}<br>
-                                                <span class="text-muted"><i>{{ $buildingHelper->getBuildingHelpString($buildingType) }}</i></span>
+                                                {!! $buildingHelper->getBuildingImplementedString($buildingType) !!}
+                                                <i class="fa fa-question-circle" data-toggle="tooltip" data-placement="top" title="{{ $buildingHelper->getBuildingHelpString($buildingType) }}"></i>
                                             </td>
                                             <td class="text-center">
                                                 {{ $selectedDominion->{'building_' . $buildingType} }}

--- a/app/resources/views/pages/dominion/military.blade.php
+++ b/app/resources/views/pages/dominion/military.blade.php
@@ -36,8 +36,8 @@
                                 @foreach ($unitHelper->getUnitTypes() as $unitType)
                                     <tr>
                                         <td>
-                                            {{ $unitHelper->getUnitName($unitType, $selectedDominion->race) }}<br>
-                                            <span class="text-muted"><i>{{ $unitHelper->getUnitHelpString($unitType, $selectedDominion->race) }}</i></span>
+                                            {{ $unitHelper->getUnitName($unitType, $selectedDominion->race) }}
+                                            <i class="fa fa-question-circle" data-toggle="tooltip" data-placement="top" title="{{ $unitHelper->getUnitHelpString($unitType, $selectedDominion->race) }}"></i>
                                         </td>
                                         <td class="text-center">{{ number_format($selectedDominion->{'military_' . $unitType}) }}</td>
                                         <td class="text-center">{{ number_format($trainingQueueService->getQueueTotalByUnitType($selectedDominion, $unitType)) }}</td>


### PR DESCRIPTION
This PR replaces the help text below an item name by a tooltip in Building (construction) and Military lists. I'm using [Bootstrap's tooltip](https://getbootstrap.com/docs/3.3/javascript/#tooltips) instead of title attribute for the sake of a better touch/mobile experience.