### PR TITLE
Dropped networth column from dominion table. Fix WaveHack/OpenDominion/#96

### DIFF
--- a/app/database/factories/ModelFactory.php
+++ b/app/database/factories/ModelFactory.php
@@ -7,7 +7,6 @@ use OpenDominion\Models\User;
 $factory->define(Dominion::class, function (Faker\Generator $faker) {
     return [
         'name' => $faker->unique()->name,
-        'networth' => 0,
         'prestige' => 250,
         'peasants' => 1300,
         'peasants_last_hour' => 0,

--- a/app/database/migrations/2017_10_14_181002_drop_networth_column_from_dominions_table.php
+++ b/app/database/migrations/2017_10_14_181002_drop_networth_column_from_dominions_table.php
@@ -1,8 +1,8 @@
 <?php
 
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class DropNetworthColumnFromDominionsTable extends Migration
 {

--- a/app/database/migrations/2017_10_14_181002_drop_networth_column_from_dominions_table.php
+++ b/app/database/migrations/2017_10_14_181002_drop_networth_column_from_dominions_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class DropNetworthColumnFromDominionsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('dominions', function (Blueprint $table) {
+            $table->dropColumn('networth');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('dominions', function (Blueprint $table) {
+            $table->integer('networth')->default(0)->after('name');
+        });
+    }
+}

--- a/app/resources/views/pages/dominion/realm.blade.php
+++ b/app/resources/views/pages/dominion/realm.blade.php
@@ -68,7 +68,7 @@
                                             --}}
                                         </td>
                                         <td class="text-center">{{ number_format($landCalculator->getTotalLand($dominion)) }}</td>
-                                        <td class="text-center">{{ number_format($dominion->networth) }}</td>
+                                        <td class="text-center">{{ number_format($networthCalculator->getDominionNetworth($dominion)) }}</td>
                                     </tr>
                                 @endif
                             @endfor

--- a/src/Console/Commands/Game/TickCommand.php
+++ b/src/Console/Commands/Game/TickCommand.php
@@ -77,7 +77,6 @@ class TickCommand extends Command
         $this->tickDominionMorale();
         $this->tickDominionSpyStrength();
         $this->tickDominionWizardStrength();
-        $this->tickDominionNetworth();
 
         DB::commit();
 
@@ -365,20 +364,6 @@ class TickCommand extends Command
         $affectedUpdated -= $affectedFinished;
 
         Log::debug("Ticked training queue, {$affectedUpdated} updated, {$affectedFinished} finished");
-    }
-
-    /**
-     * Ticks dominion networth.
-     */
-    public function tickDominionNetworth()
-    {
-        // todo: figure out what to do with dominion->networth
-        Log::debug('Tick dominion networth');
-
-        foreach ($this->getDominionsToUpdate() as $dominion) {
-            $dominion->networth = $this->networthCalculator->getDominionNetworth($dominion);
-            $dominion->save();
-        }
     }
 
     protected function getDominionsToUpdate()

--- a/src/Factories/DominionFactory.php
+++ b/src/Factories/DominionFactory.php
@@ -78,7 +78,6 @@ class DominionFactory
             'race_id' => $race->id,
 
             'name' => $name,
-            'networth' => 0,
             'prestige' => 250,
 
             'peasants' => 1300,
@@ -143,19 +142,6 @@ class DominionFactory
             'building_dock' => 0,
         ]);
 
-        $this->updateNetworth($dominion);
-
         return $dominion;
-    }
-
-    /**
-     * Calculates and updates a Dominion's networth.
-     *
-     * @param Dominion $dominion
-     */
-    public function updateNetworth(Dominion $dominion): void
-    {
-        $dominion->networth = $this->networthCalculator->getDominionNetworth($dominion);
-        $dominion->save();
     }
 }

--- a/tests/Unit/Factories/DominionFactoryTest.php
+++ b/tests/Unit/Factories/DominionFactoryTest.php
@@ -55,11 +55,4 @@ class DominionFactoryTest extends AbstractBrowserKitTestCase
     }
 
     // todo: test realmType / multiple dominions in realm?
-
-    public function testCreateUpdatesDominionNetworth()
-    {
-        $dominion = $this->dominionFactory->create($this->user, $this->round, $this->race, 'random', 'Dummy');
-
-        $this->assertEquals(6450, $dominion->networth);
-    }
 }


### PR DESCRIPTION
This PR drops `networth` column from `dominions` table. It also removes the references to that column from the app (model, tests, views, etc.).