### PR TITLE
Renamed 'construction' routes to 'construct'. Fix WaveHack/OpenDominion/#92

### DIFF
--- a/app/resources/views/pages/dominion/construction.blade.php
+++ b/app/resources/views/pages/dominion/construction.blade.php
@@ -10,7 +10,7 @@
                 <div class="box-header with-border">
                     <h3 class="box-title"><i class="fa fa-home"></i> Construct Buildings</h3>
                 </div>
-                <form action="{{ route('dominion.construction') }}" method="post" role="form">
+                <form action="{{ route('dominion.construct') }}" method="post" role="form">
                     {!! csrf_field() !!}
                     <div class="box-body table-responsive no-padding">
                         <table class="table">
@@ -79,7 +79,7 @@
             <div class="box">
                 <div class="box-header with-border">
                     <h3 class="box-title">Information</h3>
-                    <a href="{{ route('dominion.advisors.construction') }}" class="pull-right">Construction Advisor</a>
+                    <a href="{{ route('dominion.advisors.construct') }}" class="pull-right">Construction Advisor</a>
                 </div>
                 <div class="box-body">
                     <p>Construction will let you construct additional buildings and will take <b>12 hours</b> to process.</p>

--- a/app/resources/views/partials/dominion/advisor-selector.blade.php
+++ b/app/resources/views/partials/dominion/advisor-selector.blade.php
@@ -28,7 +28,7 @@
             <div class="col-xs-12 visible-xs">&nbsp;</div>
 
             <div class="col-xs-4 col-sm-3 col-md-2 col-lg-1">
-                <a href="{{ route('dominion.advisors.construction') }}" class="btn btn-app btn-block">
+                <a href="{{ route('dominion.advisors.construct') }}" class="btn btn-app btn-block">
                     <i class="fa fa-home"></i> Construction
                 </a>
             </div>

--- a/app/resources/views/partials/main-sidebar.blade.php
+++ b/app/resources/views/partials/main-sidebar.blade.php
@@ -23,7 +23,7 @@
 
                 <li class="header">DOMINION</li>
                 <li class="{{ Route::is('dominion.explore') ? 'active' : null }}"><a href="{{ route('dominion.explore') }}"><i class="fa fa-search fa-fw"></i> <span>Explore Land</span></a></li>
-                <li class="{{ Route::is('dominion.construction') ? 'active' : null }}"><a href="{{ route('dominion.construction') }}"><i class="fa fa-home fa-fw"></i> <span>Construct Buildings</span></a></li>
+                <li class="{{ Route::is('dominion.construct') ? 'active' : null }}"><a href="{{ route('dominion.construct') }}"><i class="fa fa-home fa-fw"></i> <span>Construct Buildings</span></a></li>
                 <li class="{{ Route::is('dominion.rezone') ? 'active' : null }}"><a href="{{ route('dominion.rezone') }}"><i class="ra ra-cycle ra-fw"></i> <span>Re-zone Land</span></a></li>
                 {{--<li class="{{ Route::is('dominion.improvements') ? 'active' : null }}"><a href="{{ route('dominion.improvements') }}"><i class="fa fa-arrow-up fa-fw"></i> <span>Improvements</span></a></li>--}}
                 <li class="{{ Route::is('dominion.bank') ? 'active' : null }}"><a href="{{ route('dominion.bank') }}"><i class="ra ra-capitol ra-fw"></i> <span>National Bank</span></a></li>

--- a/app/routes/web.php
+++ b/app/routes/web.php
@@ -103,7 +103,7 @@ $router->group(['middleware' => 'auth'], function (Router $router) {
             $router->get('advisors/production')->uses('Dominion\AdvisorsController@getAdvisorsProduction')->name('advisors.production');
             $router->get('advisors/military')->uses('Dominion\AdvisorsController@getAdvisorsMilitary')->name('advisors.military');
             $router->get('advisors/land')->uses('Dominion\AdvisorsController@getAdvisorsLand')->name('advisors.land');
-            $router->get('advisors/construction')->uses('Dominion\AdvisorsController@getAdvisorsConstruction')->name('advisors.construction');
+            $router->get('advisors/construct')->uses('Dominion\AdvisorsController@getAdvisorsConstruction')->name('advisors.construct');
             $router->get('advisors/magic')->uses('Dominion\AdvisorsController@getAdvisorsMagic')->name('advisors.magic');
             $router->get('advisors/rankings')->uses('Dominion\AdvisorsController@getAdvisorsRankings')->name('advisors.rankings');
             $router->get('advisors/statistics')->uses('Dominion\AdvisorsController@getAdvisorsStatistics')->name('advisors.statistics');
@@ -113,8 +113,8 @@ $router->group(['middleware' => 'auth'], function (Router $router) {
             $router->post('explore')->uses('Dominion\ExplorationController@postExplore');
 
             // Construction
-            $router->get('construction')->uses('Dominion\ConstructionController@getConstruction')->name('construction');
-            $router->post('construction')->uses('Dominion\ConstructionController@postConstruction');
+            $router->get('construct')->uses('Dominion\ConstructionController@getConstruction')->name('construct');
+            $router->post('construct')->uses('Dominion\ConstructionController@postConstruction');
             $router->get('destroy')->uses('Dominion\ConstructionController@getDestroy')->name('destroy');
             $router->post('destroy')->uses('Dominion\ConstructionController@postDestroy');
 

--- a/src/Http/Controllers/Dominion/ConstructionController.php
+++ b/src/Http/Controllers/Dominion/ConstructionController.php
@@ -58,7 +58,7 @@ class ConstructionController extends AbstractDominionController
         ));
 
         $request->session()->flash('alert-success', $message);
-        return redirect()->route('dominion.construction');
+        return redirect()->route('dominion.construct');
     }
 
     public function getDestroy()


### PR DESCRIPTION
This PR closes #92. It simply refactors some route names to replace `construction` by `construct`.