### PR TITLE
Improved readability of barren land indicator on construction page.

### DIFF
--- a/app/resources/assets/sass/app.scss
+++ b/app/resources/assets/sass/app.scss
@@ -32,3 +32,9 @@
 .align-middle {
   vertical-align: middle !important;
 }
+
+// Construction
+.barren-land {
+  margin-top: 10px;
+  font-weight: normal;
+}

--- a/app/resources/views/pages/dominion/construction.blade.php
+++ b/app/resources/views/pages/dominion/construction.blade.php
@@ -29,7 +29,10 @@
 
                                 <thead>
                                     <tr>
-                                        <th colspan="3">{{ ucfirst($landType) }} <span class="small">(Barren: {{ number_format($landCalculator->getTotalBarrenLandByLandType($selectedDominion, $landType)) }})</span></th>
+                                        <th colspan="4">
+                                            <span class="pull-right barren-land">Barren: <strong>{{ number_format($landCalculator->getTotalBarrenLandByLandType($selectedDominion, $landType)) }}</strong></span>
+                                            <h4>{{ ucfirst($landType) }}</h4>
+                                        </th>
                                     </tr>
                                     <tr>
                                         <th>Building</th>


### PR DESCRIPTION
This PR closes WaveHack/OpenDominion/#98. It moves the barren land amount to the right and also gives more emphasis to the land type title, wrapping it in a `<h4>`.