### PR TITLE
Changed council threads sorting to use the last activity to order.

### DIFF
--- a/src/Http/Controllers/Dominion/CouncilController.php
+++ b/src/Http/Controllers/Dominion/CouncilController.php
@@ -3,6 +3,7 @@
 namespace OpenDominion\Http\Controllers\Dominion;
 
 use Exception;
+use Illuminate\Support\Facades\DB;
 use OpenDominion\Http\Requests\Dominion\Council\CreatePostRequest;
 use OpenDominion\Http\Requests\Dominion\Council\CreateThreadRequest;
 use OpenDominion\Models\Council;
@@ -17,10 +18,11 @@ class CouncilController extends AbstractDominionController
         $dominion = $this->getSelectedDominion();
         $realm = $dominion->realm;
         $councilThreads = $realm->councilThreads() // todo: move to CouncilService
+            ->select([ 'council_threads.*', DB::raw('ifnull(council_posts.created_at, council_threads.created_at) as last_activity') ])
             ->with(['dominion', 'posts.dominion'])
             ->leftJoin('council_posts', 'council_posts.council_thread_id', '=', 'council_threads.id')
             ->groupBy('council_threads.id')
-            ->orderBy('council_posts.created_at', 'desc')
+            ->orderBy('last_activity', 'desc')
             ->get(['council_threads.*']); // hey it works ¯\_(ツ)_/¯
 
         return view('pages.dominion.council.index', compact(


### PR DESCRIPTION
This PR closes #141. The threads are now sorted by the last activity. It considers the last post date or the thread creation date when it doesn't have any posts (A.K.A. a new thread).