### PR TITLE
Select the previously chosen resource in the improvements dropdown

### DIFF
--- a/app/resources/views/pages/dominion/improvements.blade.php
+++ b/app/resources/views/pages/dominion/improvements.blade.php
@@ -54,10 +54,10 @@
                     <div class="box-footer">
                         <div class="pull-right">
                             <select name="resource" class="form-control">
-                                <option value="platinum">Platinum</option>
-                                <option value="lumber">Lumber</option>
-                                <option value="ore">Ore</option>
-                                <option value="gems" selected>Gems</option>
+                                <option value="platinum" {{ $selectedResource == 'platinum' ? 'selected' : ''}}>Platinum</option>
+                                <option value="lumber" {{ $selectedResource  == 'lumber' ? 'selected' : ''}}>Lumber</option>
+                                <option value="ore" {{ $selectedResource  == 'ore' ? 'selected' : ''}}>Ore</option>
+                                <option value="gems" {{ $selectedResource  == '' ? 'selected' : ''}}>Gems</option>
                             </select>
                         </div>
 

--- a/src/Http/Controllers/Dominion/ImprovementController.php
+++ b/src/Http/Controllers/Dominion/ImprovementController.php
@@ -17,6 +17,7 @@ class ImprovementController extends AbstractDominionController
         return view('pages.dominion.improvements', [
             'improvementCalculator' => app(ImprovementCalculator::class),
             'improvementHelper' => app(ImprovementHelper::class),
+            'selectedResource' => app('request')->input('resource'),
         ]);
     }
 
@@ -48,6 +49,13 @@ class ImprovementController extends AbstractDominionController
         ));
 
         $request->session()->flash('alert-success', $result['message']);
-        return redirect()->route('dominion.improvements');
+
+        $parameters = [];
+        if ($request->get('resource') != 'gems') {
+            $parameters = [
+                'resource' => $request->get('resource')
+            ];
+        }
+        return redirect()->route('dominion.improvements', $parameters);
     }
 }


### PR DESCRIPTION
While adding improvements, the request parameter gets passed to the post request so the dropdown can be pre-selected with the previously selected resource.