### PR TITLE
Daily Ranking Bug

### DIFF
--- a/src/Console/Commands/Game/TickCommand.php
+++ b/src/Console/Commands/Game/TickCommand.php
@@ -507,6 +507,8 @@ class TickCommand extends Command
 
         //Getting all rounds
         $rounds = DB::table('rounds')
+            ->where('start_date', '<=', $this->now)
+            ->where('end_date', '>', $this->now)
             ->get();
         
         foreach($rounds as $round){

--- a/src/Console/Commands/Game/TickCommand.php
+++ b/src/Console/Commands/Game/TickCommand.php
@@ -516,6 +516,7 @@ class TickCommand extends Command
         foreach ($result as $row) {
             DB::table('daily_rankings')
                 ->where('id', $row->id)
+                ->where('round_id', $round->id)
                 ->update([
                     'land_rank' => $rank,
                     'land_rank_change' => (($row->land_rank !== null) ? ($row->land_rank - $rank) : 0),

--- a/src/Console/Commands/Game/TickCommand.php
+++ b/src/Console/Commands/Game/TickCommand.php
@@ -440,9 +440,9 @@ class TickCommand extends Command
      */
     public function resetDailyBonuses()
     {
-        /*if ($this->now->hour !== 0) {
+        if ($this->now->hour !== 0) {
             return;
-        }*/
+        }
 
         Log::debug('Resetting daily bonuses');
 
@@ -455,10 +455,10 @@ class TickCommand extends Command
 
     public function updateDailyRankings()
     {
-        /*if ($this->now->hour !== 0) {
+        if ($this->now->hour !== 0) {
             return;
         }
-        */
+        
         Log::debug('Updating daily rankings');
 
         // todo: needs updating per round. make GameTickService and tick each round individually. at least for rankings

--- a/src/Console/Commands/Game/TickCommand.php
+++ b/src/Console/Commands/Game/TickCommand.php
@@ -514,6 +514,7 @@ class TickCommand extends Command
         $rank = 1;
 
         foreach ($result as $row) {
+            if($row->round_id == (int)$round->id){
             DB::table('daily_rankings')
                 ->where('id', $row->id)
                 ->where('round_id', $round->id)
@@ -521,7 +522,7 @@ class TickCommand extends Command
                     'land_rank' => $rank,
                     'land_rank_change' => (($row->land_rank !== null) ? ($row->land_rank - $rank) : 0),
                 ]);
-            if($row->round_id == (int)$round->id){
+            
             $rank++;
             }
         }
@@ -534,6 +535,7 @@ class TickCommand extends Command
         $rank = 1;
 
         foreach ($result as $row) {
+            if($row->round_id == (int)$round->id){
             DB::table('daily_rankings')
                 ->where('id', $row->id)
                 ->update([
@@ -543,6 +545,7 @@ class TickCommand extends Command
 
             $rank++;
         }
+    }
     }
     }
 

--- a/src/Console/Commands/Game/TickCommand.php
+++ b/src/Console/Commands/Game/TickCommand.php
@@ -509,44 +509,44 @@ class TickCommand extends Command
         $rounds = DB::table('rounds')
             ->get();
         
-
         foreach($rounds as $round){
-        $rank = 1;
+            $rank = 1;
 
-        foreach ($result as $row) {
-            if($row->round_id == (int)$round->id){
-            DB::table('daily_rankings')
-                ->where('id', $row->id)
-                ->where('round_id', $round->id)
-                ->update([
-                    'land_rank' => $rank,
-                    'land_rank_change' => (($row->land_rank !== null) ? ($row->land_rank - $rank) : 0),
-                ]);
+            foreach ($result as $row) {
+                if($row->round_id == (int)$round->id){
+                    DB::table('daily_rankings')
+                        ->where('id', $row->id)
+                        ->where('round_id', $round->id)
+                        ->update([
+                            'land_rank' => $rank,
+                            'land_rank_change' => (($row->land_rank !== null) ? ($row->land_rank - $rank) : 0),
+                        ]);
+                
             
-            $rank++;
+                    $rank++;
+                }
+            }
+
+            $result = DB::table('daily_rankings')
+                ->orderBy('networth', 'desc')
+                ->orderBy(DB::raw('COALESCE(networth_rank, created_at)'))
+                ->get();
+
+            $rank = 1;
+
+            foreach ($result as $row) {
+                if($row->round_id == (int)$round->id){
+                    DB::table('daily_rankings')
+                        ->where('id', $row->id)
+                        ->update([
+                            'networth_rank' => $rank,
+                            'networth_rank_change' => (($row->networth_rank !== null) ? ($row->networth_rank - $rank) : 0),
+                        ]);
+
+                    $rank++;
+                }
             }
         }
-
-        $result = DB::table('daily_rankings')
-            ->orderBy('networth', 'desc')
-            ->orderBy(DB::raw('COALESCE(networth_rank, created_at)'))
-            ->get();
-
-        $rank = 1;
-
-        foreach ($result as $row) {
-            if($row->round_id == (int)$round->id){
-            DB::table('daily_rankings')
-                ->where('id', $row->id)
-                ->update([
-                    'networth_rank' => $rank,
-                    'networth_rank_change' => (($row->networth_rank !== null) ? ($row->networth_rank - $rank) : 0),
-                ]);
-
-            $rank++;
-        }
-    }
-    }
     }
 
     protected function getDominionsToUpdate()

--- a/src/Console/Commands/Game/TickCommand.php
+++ b/src/Console/Commands/Game/TickCommand.php
@@ -440,9 +440,9 @@ class TickCommand extends Command
      */
     public function resetDailyBonuses()
     {
-        if ($this->now->hour !== 0) {
+        /*if ($this->now->hour !== 0) {
             return;
-        }
+        }*/
 
         Log::debug('Resetting daily bonuses');
 
@@ -455,10 +455,10 @@ class TickCommand extends Command
 
     public function updateDailyRankings()
     {
-        if ($this->now->hour !== 0) {
+        /*if ($this->now->hour !== 0) {
             return;
         }
-
+        */
         Log::debug('Updating daily rankings');
 
         // todo: needs updating per round. make GameTickService and tick each round individually. at least for rankings
@@ -505,6 +505,12 @@ class TickCommand extends Command
             ->orderBy(DB::raw('COALESCE(land_rank, created_at)'))
             ->get();
 
+        //Getting all rounds
+        $rounds = DB::table('rounds')
+            ->get();
+        
+
+        foreach($rounds as $round){
         $rank = 1;
 
         foreach ($result as $row) {
@@ -514,8 +520,9 @@ class TickCommand extends Command
                     'land_rank' => $rank,
                     'land_rank_change' => (($row->land_rank !== null) ? ($row->land_rank - $rank) : 0),
                 ]);
-
+            if($row->round_id == (int)$round->id){
             $rank++;
+            }
         }
 
         $result = DB::table('daily_rankings')
@@ -535,6 +542,7 @@ class TickCommand extends Command
 
             $rank++;
         }
+    }
     }
 
     protected function getDominionsToUpdate()


### PR DESCRIPTION
#170 

So this fixed the ranking by looping over the daily rankings table for each round while checking the id and only setting the ranking if the round_ids are equal. 

It works but I guess I could see it taking a bit of time if we ever have a huge number of rounds? 
