### PR TITLE
Days bug

### DIFF
--- a/app/resources/views/partials/main-footer.blade.php
+++ b/app/resources/views/partials/main-footer.blade.php
@@ -4,9 +4,10 @@
         @if (isset($selectedDominion) && ($selectedDominion->round->isActive()))
             @php
             $diff = $selectedDominion->round->start_date->subDays(1)->diff(Carbon\Carbon::now());
+            $roundDay = $selectedDominion->round->start_date->subDays(1)->diffInDays(Carbon\Carbon::now());
             $roundDurationInDays = $selectedDominion->round->start_date->diffInDays($selectedDominion->round->end_date);
 
-            echo "Day <strong>{$diff->d}</strong>/{$roundDurationInDays}, hour <strong>{$diff->h}</strong>.";
+            echo "Day <strong>{$roundDay}</strong>/{$roundDurationInDays}, hour <strong>{$diff->h}</strong>.";
 
             @endphp
         @endif


### PR DESCRIPTION
#186 

Fixed the issue. Problem was that because `$diff` is a specific date-time it didn't support any differences over 31 days. Fixed it by having `$roundDay` to calculate the diff between the start of the round and the current time/date.