### PR TITLE
Replaces usages of Carbon\Carbon::now() with Laravel's built-in now() helper.

### DIFF
--- a/app/resources/views/errors/503.blade.php
+++ b/app/resources/views/errors/503.blade.php
@@ -72,15 +72,15 @@
                                             <dt>Went down:</dt>
                                             <dd>
                                                 <abbr title="Went down at {{ $exception->wentDownAt }}">
-                                                    {{ $exception->wentDownAt->diffInMinutes(\Carbon\Carbon::now()) + 1 }} minute(s) ago
+                                                    {{ $exception->wentDownAt->diffInMinutes(now()) + 1 }} minute(s) ago
                                                 </abbr>
                                             </dd>
                                             <dt>Estimated back:</dt>
                                             <dd>
-                                                @if (\Carbon\Carbon::now() >= $exception->willBeAvailableAt)
+                                                @if (now() >= $exception->willBeAvailableAt)
                                                     Any second now!
                                                 @else
-                                                    In {{ $exception->willBeAvailableAt->diffInMinutes(\Carbon\Carbon::now()) + 1 }} minute(s)
+                                                    In {{ $exception->willBeAvailableAt->diffInMinutes(now()) + 1 }} minute(s)
                                                 @endif
                                             </dd>
                                         @endif

--- a/app/resources/views/partials/main-footer.blade.php
+++ b/app/resources/views/partials/main-footer.blade.php
@@ -3,8 +3,8 @@
     <div class="pull-right">
         @if (isset($selectedDominion) && ($selectedDominion->round->isActive()))
             @php
-            $diff = $selectedDominion->round->start_date->subDays(1)->diff(Carbon\Carbon::now());
-            $roundDay = $selectedDominion->round->start_date->subDays(1)->diffInDays(Carbon\Carbon::now());
+            $diff = $selectedDominion->round->start_date->subDays(1)->diff(now());
+            $roundDay = $selectedDominion->round->start_date->subDays(1)->diffInDays(now());
             $roundDurationInDays = $selectedDominion->round->start_date->diffInDays($selectedDominion->round->end_date);
 
             echo "Day <strong>{$roundDay}</strong>/{$roundDurationInDays}, hour <strong>{$diff->h}</strong>.";

--- a/app/routes/api.php
+++ b/app/routes/api.php
@@ -28,8 +28,8 @@ $router->group(['prefix' => 'v1'], function (Router $router) {
             'players' => [
                 'registered' => \OpenDominion\Models\User::count(),
                 'active' => \OpenDominion\Models\Dominion::whereHas('round', function ($q) {
-                    $q->where('start_date', '<=', \Carbon\Carbon::now())
-                        ->where('end_date', '>', \Carbon\Carbon::now());
+                    $q->where('start_date', '<=', now())
+                        ->where('end_date', '>', now());
                 })->count(),
             ],
             'links' => [

--- a/src/Console/Commands/Game/TickCommand.php
+++ b/src/Console/Commands/Game/TickCommand.php
@@ -62,7 +62,7 @@ class TickCommand extends Command
         $this->populationCalculator = app(PopulationCalculator::class);
         $this->productionCalculator = app(ProductionCalculator::class);
 
-        $this->now = Carbon::now();
+        $this->now = now();
     }
 
     /**

--- a/src/Models/Dominion.php
+++ b/src/Models/Dominion.php
@@ -2,7 +2,6 @@
 
 namespace OpenDominion\Models;
 
-use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Notifications\Notifiable;
 use OpenDominion\Services\Dominion\SelectorService;
@@ -43,8 +42,8 @@ class Dominion extends AbstractModel
     public function scopeActive(Builder $query)
     {
         return $query->whereHas('round', function (Builder $query) {
-            $query->where('start_date', '<=', Carbon::now())
-                ->where('end_date', '>', Carbon::now());
+            $query->where('start_date', '<=', now())
+                ->where('end_date', '>', now());
         });
     }
 
@@ -90,6 +89,6 @@ class Dominion extends AbstractModel
      */
     public function isLocked()
     {
-        return (Carbon::now() >= $this->round->end_date);
+        return (now() >= $this->round->end_date);
     }
 }

--- a/src/Models/Round.php
+++ b/src/Models/Round.php
@@ -81,7 +81,7 @@ class Round extends AbstractModel
      */
     public function hasStarted()
     {
-        return ($this->start_date <= Carbon::now());
+        return ($this->start_date <= now());
     }
 
     /**
@@ -91,7 +91,7 @@ class Round extends AbstractModel
      */
     public function hasEnded()
     {
-        return ($this->end_date <= Carbon::now());
+        return ($this->end_date <= now());
     }
 
     /**
@@ -111,7 +111,7 @@ class Round extends AbstractModel
      */
     public function daysUntilStart()
     {
-        return $this->start_date->diffInDays(Carbon::now()) + 1;
+        return $this->start_date->diffInDays(now()) + 1;
     }
 
     /**
@@ -121,7 +121,7 @@ class Round extends AbstractModel
      */
     public function daysUntilEnd()
     {
-        return $this->end_date->diffInDays(Carbon::now()) + 1;
+        return $this->end_date->diffInDays(now()) + 1;
     }
 
     /**

--- a/src/Services/Dominion/Actions/SpellActionService.php
+++ b/src/Services/Dominion/Actions/SpellActionService.php
@@ -2,7 +2,6 @@
 
 namespace OpenDominion\Services\Dominion\Actions;
 
-use Carbon\Carbon;
 use DB;
 use Exception;
 use OpenDominion\Calculators\Dominion\LandCalculator;
@@ -93,7 +92,7 @@ class SpellActionService
                     ->where($where)
                     ->update([
                         'duration' => $spellInfo['duration'],
-                        'updated_at' => Carbon::now(),
+                        'updated_at' => now(),
                     ]);
 
             } else {
@@ -103,8 +102,8 @@ class SpellActionService
                         'spell' => $spell,
                         'duration' => $spellInfo['duration'],
                         'cast_by_dominion_id' => $dominion->id, // todo
-                        'created_at' => Carbon::now(),
-                        'updated_at' => Carbon::now(),
+                        'created_at' => now(),
+                        'updated_at' => now(),
                     ]);
             }
 

--- a/src/Services/Dominion/ProtectionService.php
+++ b/src/Services/Dominion/ProtectionService.php
@@ -44,7 +44,7 @@ class ProtectionService
      */
     public function isUnderProtection(Dominion $dominion): bool
     {
-        return ($this->getProtectionEndDate($dominion) >= Carbon::now());
+        return ($this->getProtectionEndDate($dominion) >= now());
     }
 
     /**
@@ -59,11 +59,11 @@ class ProtectionService
             return 0;
         }
 
-        $minutes = (int)Carbon::now()->format('i');
-        $seconds = (int)Carbon::now()->format('s');
+        $minutes = (int)now()->format('i');
+        $seconds = (int)now()->format('s');
 
         $fraction = (1 - ((($minutes * 60) + $seconds) / 3600));
 
-        return ($this->getProtectionEndDate($dominion)->diffInHours(Carbon::now()) + $fraction);
+        return ($this->getProtectionEndDate($dominion)->diffInHours(now()) + $fraction);
     }
 }


### PR DESCRIPTION
- Fixes #188 
- Removes unused 'use' statements in files where no other instances of Carbon are being used.