### PR TITLE
Realm page networth calculation is off

### DIFF
--- a/src/Models/Race.php
+++ b/src/Models/Race.php
@@ -17,8 +17,7 @@ class Race extends AbstractModel
     public function units()
     {
         return $this->hasMany(Unit::class)
-            ->orderBy('slot')
-            ->limit(4);
+            ->orderBy('slot');
     }
 
     /**


### PR DESCRIPTION
Limit for relation is used for all objects relationships. So this was not visible before there where more than one race in a realm. The reason it's not in the rankings is because rankings queries db for every dominion. It is not done in a single query.