### PR TITLE
Active spells cache was leaking for invasions, solves dp bug.

### DIFF
--- a/src/Calculators/Dominion/SpellCalculator.php
+++ b/src/Calculators/Dominion/SpellCalculator.php
@@ -70,7 +70,7 @@ class SpellCalculator
      */
     public function getActiveSpells(Dominion $dominion, bool $forceRefresh = false): Collection
     {
-        $cacheKey = "{$dominion->id}";
+        $cacheKey = $dominion->id;
 
         if (!$forceRefresh && array_has($this->activeSpells, $cacheKey)) {
             return collect(array_get($this->activeSpells, $cacheKey));

--- a/src/Calculators/Dominion/SpellCalculator.php
+++ b/src/Calculators/Dominion/SpellCalculator.php
@@ -16,8 +16,8 @@ class SpellCalculator
     /** @var SpellHelper */
     protected $spellHelper;
 
-    /** @var Collection */
-    protected $activeSpells;
+    /** @var array */
+    protected $activeSpells = [];
 
     /**
      * SpellCalculator constructor.
@@ -70,21 +70,27 @@ class SpellCalculator
      */
     public function getActiveSpells(Dominion $dominion, bool $forceRefresh = false): Collection
     {
-        if ($this->activeSpells === null || $forceRefresh) {
-            $this->activeSpells = DB::table('active_spells')
-                ->join('dominions', 'dominions.id', '=', 'cast_by_dominion_id')
-                ->join('realms', 'realms.id', '=', 'dominions.realm_id')
-                ->where('dominion_id', $dominion->id)
-                ->orderBy('duration', 'desc')
-                ->orderBy('created_at')
-                ->get([
-                    'active_spells.*',
-                    'dominions.name AS cast_by_dominion_name',
-                    'realms.number AS cast_by_dominion_realm_number',
-                ]);
+        $cacheKey = "{$dominion->id}";
+
+        if (!$forceRefresh && array_has($this->activeSpells, $cacheKey)) {
+            return collect(array_get($this->activeSpells, $cacheKey));
         }
 
-        return $this->activeSpells;
+        $data = DB::table('active_spells')
+            ->join('dominions', 'dominions.id', '=', 'cast_by_dominion_id')
+            ->join('realms', 'realms.id', '=', 'dominions.realm_id')
+            ->where('dominion_id', $dominion->id)
+            ->orderBy('duration', 'desc')
+            ->orderBy('created_at')
+            ->get([
+                'active_spells.*',
+                'dominions.name AS cast_by_dominion_name',
+                'realms.number AS cast_by_dominion_realm_number',
+            ]);
+
+        array_set($this->activeSpells, $cacheKey, $data->toArray());
+
+        return $data;
     }
 
     /**


### PR DESCRIPTION
Since the attacking dominions spells are checked first, they get cached. So if attacker has Ares on it doesn't matter if the defender has it. It will still be found in the cache.