### PR TITLE
added support for multiple unit perks

### DIFF
--- a/app/database/migrations/2019_05_17_191915_create_unit_perks_table.php
+++ b/app/database/migrations/2019_05_17_191915_create_unit_perks_table.php
@@ -1,0 +1,47 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateUnitPerksTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('unit_perks', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('unit_id')->unsigned();
+            $table->integer('unit_perk_type_id')->unsigned();
+            $table->string('value')->nullable();
+            $table->timestamps();
+
+            $table->foreign('unit_id')->references('id')->on('units');
+            $table->foreign('unit_perk_type_id')->references('id')->on('unit_perk_types');
+        });
+
+        Schema::table('units', function (Blueprint $table) {
+            $table->dropColumn('unit_perk_type_id');
+            $table->dropColumn('unit_perk_type_values');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('unit_perks');
+
+        Schema::table('units', function (Blueprint $table) {
+            $table->integer('unit_perk_type_id')->unsigned()->nullable();
+            $table->string('unit_perk_type_values')->nullable();
+        });
+    }
+}

--- a/src/Calculators/Dominion/CasualtiesCalculator.php
+++ b/src/Calculators/Dominion/CasualtiesCalculator.php
@@ -90,11 +90,7 @@ class CasualtiesCalculator
                 $unitsAtHome = ($totalUnitAmount - ($units[$slot] ?? 0));
                 $unitsAtHomePerSlot[$slot] = $unitsAtHome;
 
-                if ($unit->perkType === null) {
-                    continue;
-                }
-
-                if (($unit->perkType->key === 'reduce_combat_losses')) {
+                if ($unit->getPerkValue('reduce_combat_losses') !== 0) {
                     // todo: hacky workaround for not allowing RCL for gobbos (feedback from Gabbe)
                     //  Needs to be refactored later; unit perk should be renamed in the yml to reduce_combat_losses_defense
                     if ($dominion->race->name === 'Goblin') {
@@ -182,11 +178,7 @@ class CasualtiesCalculator
 
                 $unitsAtHomePerSlot[$slot] = $dominion->$unitKey;
 
-                if ($unit->perkType === null) {
-                    continue;
-                }
-
-                if (($unit->perkType->key === 'reduce_combat_losses')) {
+                if ($unit->getPerkValue('reduce_combat_losses') !== 0) {
                     $unitsAtHomeRCLSlot = $slot;
                 }
             }

--- a/src/Calculators/Dominion/MilitaryCalculator.php
+++ b/src/Calculators/Dominion/MilitaryCalculator.php
@@ -291,12 +291,8 @@ class MilitaryCalculator
 
         // Add units which count as (partial) spies (Lizardfolk Chameleon)
         foreach ($dominion->race->units as $unit) {
-            if ($unit->perkType === null) {
-                continue;
-            }
-
-            if ($unit->perkType->key === 'counts_as_spy') {
-                $spies += floor($dominion->{"military_unit{$unit->slot}"} * (float)$unit->unit_perk_type_values);
+            if ($unit->getPerkValue('counts_as_spy') !== 0) {
+                $spies += floor($dominion->{"military_unit{$unit->slot}"} * (float)$unit->getPerkValue('counts_as_spy'));
             }
         }
 

--- a/src/Helpers/UnitHelper.php
+++ b/src/Helpers/UnitHelper.php
@@ -63,13 +63,9 @@ class UnitHelper
         ];
 
         foreach ($race->units as $unit) {
-            $perkType = $unit->perkType;
-
-            if ($perkType === null) {
-                continue;
+            foreach ($unit->perks->whereIn('key', array_keys($perkTypeStrings)) as $perk) {
+                $helpStrings['unit' . $unit->slot] .= ('<br><br>' . sprintf($perkTypeStrings[$perk->key], $perk->pivot->value));
             }
-
-            $helpStrings['unit' . $unit->slot] .= ('<br><br>' . sprintf($perkTypeStrings[$perkType->key], $unit->unit_perk_type_values));
         }
 
         return $helpStrings[$unitType] ?: null;

--- a/src/Models/Dominion.php
+++ b/src/Models/Dominion.php
@@ -205,12 +205,8 @@ class Dominion extends AbstractModel
         $bonus = 0;
 
         foreach ($this->race->units as $unit) {
-            if ($unit->perkType === null) {
-                continue;
-            }
-
-            if ($unit->perkType->key === $resourceType) {
-                $bonus += ($this->{'military_unit' . $unit->slot} * (float)$unit->unit_perk_type_values);
+            if ($unit->getPerkValue($resourceType) !== 0) {
+                $bonus += ($this->{'military_unit' . $unit->slot} * (float)$unit->getPerkValue($resourceType));
             }
         }
 

--- a/src/Models/Race.php
+++ b/src/Models/Race.php
@@ -56,24 +56,17 @@ class Race extends AbstractModel
             $unitPerkTypes = [$unitPerkTypes];
         }
 
-        /** @var Collection|Unit[] $unitCollection */
-        $unitCollection = $this->units->filter(function (Unit $unit) use ($slot, $unitPerkTypes) {
-            return (
-                ($unit->slot === $slot) &&
-                ($unit->whereHas('perks', function(Builder $query) use ($unitPerkTypes) {
-                    $query->whereIn('key', $unitPerkTypes);
-                })->count() > 0)
-            );
-        });
-
+        $unitCollection = $this->units->where('slot', '=', $slot);
         if ($unitCollection->isEmpty()) {
             return $default;
         }
 
-        $perkValue = $unitCollection->first()->perks->filter(function(UnitPerkType $unitPerkType) use ($unitPerkTypes) {
-            return in_array($unitPerkType->key, $unitPerkTypes);
-        })->first()->pivot->value;
+        $perkCollection = $unitCollection->first()->perks->whereIn('key', $unitPerkTypes);
+        if ($perkCollection->isEmpty()) {
+            return $default;
+        }
 
+        $perkValue = $perkCollection->first()->pivot->value;
         if (str_contains($perkValue, ',')) {
             $perkValue = explode(',', $perkValue);
         }

--- a/src/Models/Race.php
+++ b/src/Models/Race.php
@@ -14,7 +14,7 @@ class Race extends AbstractModel
 
     public function perks()
     {
-        return $this->belongsToMany(RacePerkType::class, 'race_perks', 'race_id', 'race_perk_type_id')->withTimestamps();
+        return $this->belongsToMany(RacePerkType::class, 'race_perks', 'race_id', 'race_perk_type_id')->withTimestamps()->withPivot('value');
     }
 
     public function units()
@@ -39,7 +39,7 @@ class Race extends AbstractModel
             return 0;
         }
 
-        return ((float)$perks->first()->value / 100);
+        return ((float)$perks->first()->pivot->value / 100);
     }
 
     /**

--- a/src/Models/RacePerkType.php
+++ b/src/Models/RacePerkType.php
@@ -4,13 +4,8 @@ namespace OpenDominion\Models;
 
 class RacePerkType extends AbstractModel
 {
-    public function perks()
-    {
-        return $this->hasMany(RacePerk::class);
-    }
-
     public function races()
     {
-        return $this->hasManyThrough(Race::class, RacePerk::class, null, 'id');
+        return $this->belongsToMany(Race::class, 'race_perks', 'race_perk_type_id', 'race_id')->withTimestamps();
     }
 }

--- a/src/Models/Unit.php
+++ b/src/Models/Unit.php
@@ -23,7 +23,7 @@ class Unit extends AbstractModel
         return $this->hasOne(Race::class);
     }
 
-    public function getPerkValue(string $key): string
+    public function getPerkValue(string $key)
     {
         $perks = $this->perks->filter(function (UnitPerkType $unitPerkType) use ($key) {
             return ($unitPerkType->key === $key);

--- a/src/Models/Unit.php
+++ b/src/Models/Unit.php
@@ -13,9 +13,9 @@ class Unit extends AbstractModel
         'need_boat' => 'boolean',
     ];
 
-    public function perkType()
+    public function perks()
     {
-        return $this->hasOne(UnitPerkType::class, 'id', 'unit_perk_type_id');
+        return $this->belongsToMany(UnitPerkType::class, 'unit_perks', 'unit_id', 'unit_perk_type_id')->withTimestamps()->withPivot('value');
     }
 
     public function race()

--- a/src/Models/Unit.php
+++ b/src/Models/Unit.php
@@ -22,4 +22,17 @@ class Unit extends AbstractModel
     {
         return $this->hasOne(Race::class);
     }
+
+    public function getPerkValue(string $key): string
+    {
+        $perks = $this->perks->filter(function (UnitPerkType $unitPerkType) use ($key) {
+            return ($unitPerkType->key === $key);
+        });
+
+        if ($perks->isEmpty()) {
+            return 0;
+        }
+
+        return $perks->first()->pivot->value;
+    }
 }

--- a/src/Models/UnitPerk.php
+++ b/src/Models/UnitPerk.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace OpenDominion\Models;
+
+class UnitPerk extends AbstractModel
+{
+    protected $casts = [
+        'value' => 'float',
+    ];
+
+    public function unit()
+    {
+        return $this->belongsTo(Unit::class);
+    }
+
+    public function type()
+    {
+        return $this->belongsTo(UnitPerkType::class, 'unit_perk_type_id');
+    }
+}

--- a/src/Models/UnitPerkType.php
+++ b/src/Models/UnitPerkType.php
@@ -6,6 +6,6 @@ class UnitPerkType extends AbstractModel
 {
     public function units()
     {
-        return $this->hasMany(Unit::class);
+        return $this->belongsToMany(Unit::class, 'unit_perks', 'unit_perk_type_id', 'unit_id')->withTimestamps();
     }
 }

--- a/src/Services/Dominion/Actions/InvadeActionService.php
+++ b/src/Services/Dominion/Actions/InvadeActionService.php
@@ -1103,8 +1103,8 @@ class InvadeActionService
             return ($unit->slot === $slot);
         })->first();
 
-        if (($unit->perkType !== null) && ($unit->perkType->key === 'faster_return')) {
-            $hours -= (int)$unit->unit_perk_type_values;
+        if ($unit->getPerkValue('faster_return') !== 0) {
+            $hours -= (int)$unit->getPerkValue('faster_return');
         }
 
         return $hours;

--- a/src/Services/Dominion/SelectorService.php
+++ b/src/Services/Dominion/SelectorService.php
@@ -70,7 +70,6 @@ class SelectorService
             $this->selectedDominion = Dominion::with([
                 'realm',
                 'race.perks',
-                'race.perks.type',
                 'race',
                 'race.units',
                 'race.units.perks'

--- a/src/Services/Dominion/SelectorService.php
+++ b/src/Services/Dominion/SelectorService.php
@@ -73,7 +73,7 @@ class SelectorService
                 'race.perks.type',
                 'race',
                 'race.units',
-                'race.units.perkType'
+                'race.units.perks'
             ])->findOrFail($dominionId);
         }
 


### PR DESCRIPTION
This is required for some of the new races. It addresses the refactor mentioned in #277.

- Database migration for unit_perks pivot table
- belongsToMany relationships for race and unit perks
- Use Eloquent's sync method for game:data:sync
- Replaces unit->perkType with unit->getPerkValue(string)
