### PR TITLE
fix issue where getMaxAfford didn't check discounted_land

### DIFF
--- a/app/resources/views/pages/dominion/construction.blade.php
+++ b/app/resources/views/pages/dominion/construction.blade.php
@@ -56,10 +56,10 @@
                     <a href="{{ route('dominion.advisors.construct') }}" class="pull-right">Construction Advisor</a>
                 </div>
                 <div class="box-body">
-                    {{-- todo: add mention of discounted_land --}}
                     <p>Construction will let you construct additional buildings and will take <b>12 hours</b> to process.</p>
                     <p>Construction per building will come at a cost of 1 acre of barren land of the building type, {{ number_format($constructionCalculator->getPlatinumCost($selectedDominion)) }} platinum and {{ number_format($constructionCalculator->getLumberCost($selectedDominion)) }} lumber.</p>
                     <p>You have {{ number_format($landCalculator->getTotalBarrenLand($selectedDominion)) }} {{ str_plural('acre', $landCalculator->getTotalBarrenLand($selectedDominion)) }} of barren land, {{ number_format($selectedDominion->resource_platinum) }} platinum and {{ number_format($selectedDominion->resource_lumber) }} lumber.</p>
+                    @if ($selectedDominion->discounted_land)<p>Additionally, {{ $selectedDominion->discounted_land }} acres from invasion can be built at reduced cost.</p>@endif
                     <p>You can afford to construct <b>{{ number_format($constructionCalculator->getMaxAfford($selectedDominion)) }} {{ str_plural('building', $constructionCalculator->getMaxAfford($selectedDominion)) }}</b> at that rate.</p>
                     <p>You may also <a href="{{ route('dominion.destroy') }}">destroy buildings</a> if you wish.</p>
                 </div>

--- a/src/Calculators/Dominion/Actions/ConstructionCalculator.php
+++ b/src/Calculators/Dominion/Actions/ConstructionCalculator.php
@@ -77,6 +77,27 @@ class ConstructionCalculator
     }
 
     /**
+     * Returns the Dominion's construction platinum cost for a given number of acres.
+     * 
+     * @param Dominion $dominion
+     * @param int $acres
+     * @return int
+     */
+    public function getTotalPlatinumCost(Dominion $dominion, int $acres): int
+    {
+        $platinumCost = $this->getPlatinumCost($dominion);
+        $totalPlatinumCost =  $platinumCost * $acres;
+
+        // Check for discounted acres after invasion
+        $discountedAcres = min($dominion->discounted_land, $acres);
+        if ($discountedAcres > 0) {
+            $totalPlatinumCost -= (int)ceil(($platinumCost * $discountedAcres) / 2);
+        }
+
+        return $totalPlatinumCost;
+    }
+
+    /**
      * Returns the Dominion's construction lumber cost (per building).
      *
      * @param Dominion $dominion
@@ -123,6 +144,27 @@ class ConstructionCalculator
     }
 
     /**
+     * Returns the Dominion's construction lumber cost for a given number of acres.
+     * 
+     * @param Dominion $dominion
+     * @param int $acres
+     * @return int
+     */
+    public function getTotalLumberCost(Dominion $dominion, int $acres): int
+    {
+        $lumberCost = $this->getLumberCost($dominion);
+        $totalLumberCost =  $lumberCost * $acres;
+
+        // Check for discounted acres after invasion
+        $discountedAcres = min($dominion->discounted_land, $acres);
+        if ($discountedAcres > 0) {
+            $totalLumberCost -= (int)ceil(($lumberCost * $discountedAcres) / 2);
+        }
+
+        return $totalLumberCost;
+    }
+
+    /**
      * Returns the maximum number of building a Dominion can construct.
      *
      * @param Dominion $dominion
@@ -151,8 +193,6 @@ class ConstructionCalculator
             // Subtract discounted building cost from available resources
             $platinumToSpend -= (int)ceil(($platinumCost * $discountedBuildings) / 2);
             $lumberToSpend -= (int)ceil(($lumberCost * $discountedBuildings) / 2);
-            // Avoid division by zero in return statement
-            if($platinumToSpend == 0 || $lumberToSpend == 0) return $discountedBuildings;
         }
 
         return $discountedBuildings + min(

--- a/src/Services/Dominion/Actions/ConstructActionService.php
+++ b/src/Services/Dominion/Actions/ConstructActionService.php
@@ -100,22 +100,8 @@ class ConstructActionService
             }
         }
 
-        $platinumCost = ($this->constructionCalculator->getPlatinumCost($dominion) * $totalBuildingsToConstruct);
-        $lumberCost = ($this->constructionCalculator->getLumberCost($dominion) * $totalBuildingsToConstruct);
-
-        // Check for discounted acres after invasion
-        $discountedBuildings = min($dominion->discounted_land, $totalBuildingsToConstruct);
-        $platinumDiscount = 0;
-        $lumberDiscount = 0;
-
-        if ($discountedBuildings > 0) {
-            // Calculate half cost
-            $platinumDiscount = (int)ceil(($this->constructionCalculator->getPlatinumCost($dominion) * $discountedBuildings) / 2); // todo: constant this with -50% or something
-            $lumberDiscount = (int)ceil(($this->constructionCalculator->getLumberCost($dominion) * $discountedBuildings) / 2);
-
-            $platinumCost -= $platinumDiscount;
-            $lumberCost -= $lumberDiscount;
-        }
+        $platinumCost = $this->constructionCalculator->getTotalPlatinumCost($dominion, $totalBuildingsToConstruct);
+        $lumberCost = $this->constructionCalculator->getTotalLumberCost($dominion, $totalBuildingsToConstruct);
 
         DB::transaction(function () use ($dominion, $data, $platinumCost, $lumberCost, $discountedBuildings) {
             $dominion->fill([


### PR DESCRIPTION
Fixes #442
ConstructionCalculator will now do the discounted land calc as coded in the ConstructActionService.
Also added a note on the construction page template, but not sure about what wording to use:
"Additionally, X acres from invasion can be built at reduced cost."