### PR TITLE
Update invasion calculator

### DIFF
--- a/app/data/races/darkelf.yml
+++ b/app/data/races/darkelf.yml
@@ -31,7 +31,7 @@ units:
       counts_as_wizard_offense: 0.2
       counts_as_wizard_defense: 0.5
       offense_from_building: wizard_guild,10,5 # building type, ratio%, max
-      defense_from_buildling: wizard_guild,10,5 # building type, ratio%, max
+      defense_from_building: wizard_guild,10,5 # building type, ratio%, max
   - name: Spirit Warrior
     cost:
       platinum: 1050
@@ -41,5 +41,5 @@ units:
       defense: 0
     perks:
       immortal_vs_land_range: 75
-      offense_staggered_land_range: 95;1,75;0.5
-      need_boat: false
+      offense_staggered_land_range: 75;0.5,95;1
+    need_boat: false

--- a/app/data/races/gnome.yml
+++ b/app/data/races/gnome.yml
@@ -40,4 +40,4 @@ units:
       offense: 5
       defense: 3
     perks:
-      offense_staggered_land_range: 85;2,75;1
+      offense_staggered_land_range: 75;1,85;2

--- a/app/database/migrations/2019_05_17_191915_create_unit_perks_table.php
+++ b/app/database/migrations/2019_05_17_191915_create_unit_perks_table.php
@@ -25,11 +25,7 @@ class CreateUnitPerksTable extends Migration
         });
 
         Schema::table('units', function (Blueprint $table) {
-            $table->dropColumn('unit_perk_type_id');
-        });
-
-        Schema::table('units', function (Blueprint $table) {
-            $table->dropColumn('unit_perk_type_values');
+            $table->dropColumn(['unit_perk_type_id', 'unit_perk_type_values']);
         });
     }
 

--- a/app/database/migrations/2019_05_17_191915_create_unit_perks_table.php
+++ b/app/database/migrations/2019_05_17_191915_create_unit_perks_table.php
@@ -26,6 +26,9 @@ class CreateUnitPerksTable extends Migration
 
         Schema::table('units', function (Blueprint $table) {
             $table->dropColumn('unit_perk_type_id');
+        });
+
+        Schema::table('units', function (Blueprint $table) {
             $table->dropColumn('unit_perk_type_values');
         });
     }

--- a/app/resources/views/pages/dominion/invade.blade.php
+++ b/app/resources/views/pages/dominion/invade.blade.php
@@ -25,7 +25,7 @@
                     </div>
                 </div>
             @else
-                <form action="{{ route('dominion.invade') }}" method="post" role="form" id ="invade_form">
+                <form action="{{ route('dominion.invade') }}" method="post" role="form" id="invade_form">
                     @csrf
 
                     <div class="box box-primary">

--- a/app/resources/views/pages/dominion/invade.blade.php
+++ b/app/resources/views/pages/dominion/invade.blade.php
@@ -25,7 +25,7 @@
                     </div>
                 </div>
             @else
-                <form action="{{ route('dominion.invade') }}" method="post" role="form">
+                <form action="{{ route('dominion.invade') }}" method="post" role="form" id ="invade_form">
                     @csrf
 
                     <div class="box box-primary">
@@ -91,9 +91,11 @@
                                                 </span>
                                             </td>
                                             <td class="text-center">
-                                                {{ (strpos($unit->power_offense, ".") !== false) ? number_format($unit->power_offense, 1) : number_format($unit->power_offense) }}
+                                                <span id="unit{{ $unitSlot }}_op">
+                                                    {{ (strpos($unit->power_offense, ".") !== false) ? number_format($unit->power_offense, 1) : number_format($unit->power_offense) }}
+                                                </span>
                                                 /
-                                                <span class="text-muted">
+                                                <span id="unit{{ $unitSlot }}_dp" class="text-muted">
                                                     {{ (strpos($unit->power_defense, ".") !== false) ? number_format($unit->power_defense, 1) : number_format($unit->power_defense) }}
                                                 </span>
                                             </td>
@@ -274,9 +276,37 @@
                 templateSelection: select2Template,
             });
 
+            updateUnitStats();
+
+            $('#target_dominion').change(function (e) {
+                updateUnitStats();
+            });
+
             // please forgive me for this monstrosity
             $('input[name^=\'unit\']').change(function (e) {
-                // var input = $(this);
+                calculate();
+            });
+
+            function updateUnitStats() {
+                $.get(
+                    "{{ route('api.dominion.invasion') }}?" + $('#invade_form').serialize(), {},
+                    function(response) {
+                        if(response.result == 'success') {
+                            $.each(response.units, function(slot, stats) {
+                                // Update unit stats data attributes
+                                $('#unit\\['+slot+'\\]').data('dp', stats.dp);
+                                $('#unit\\['+slot+'\\]').data('op', stats.op);
+                                // Update unit stats display
+                                $('#unit'+slot+'_dp').text(stats.dp.toLocaleString(undefined, {maximumFractionDigits: 2}));
+                                $('#unit'+slot+'_op').text(stats.op.toLocaleString(undefined, {maximumFractionDigits: 2}));
+                            });
+                            calculate();
+                        }
+                    }
+                );
+            }
+
+            function calculate() {
                 var invasionForceOPElement = $('#invasion-force-op');
                 var invasionForceBoatsElement = $('#invasion-force-boats');
                 var homeForcesOPElement = $('#home-forces-op');
@@ -284,7 +314,6 @@
                 var homeForcesBoatsElement = $('#home-forces-boats');
                 var invadeButtonElement = $('#invade-button');
                 var allUnitInputs = $('input[name^=\'unit\']');
-                var unitSlot = parseInt($(this).data('slot'));
 
                 var invadingForceOP = 0;
                 var invadingForceDP = 0;
@@ -304,11 +333,6 @@
                 var DPNeededToLeaveAtHome; // 33% rule
                 var allowedMaxOP; // 5:4 rule
 
-                // Calculate total unit OP / DP
-                var unitStatsElement = $('#unit' + unitSlot + '_stats');
-                unitStatsElement.find('.op').text((parseInt($(this).val() || 0) * (parseFloat($(this).data('op')) * OPMultiplier)).toLocaleString(undefined, {maximumFractionDigits: 2}));
-                unitStatsElement.find('.dp').text((parseInt($(this).val() || 0) * (parseFloat($(this).data('dp')) * DPMultiplier)).toLocaleString(undefined, {maximumFractionDigits: 2}));
-
                 // Calculate invading force OP / DP
                 allUnitInputs.each(function () {
                     // var unitAmount = parseInt($(this).data('amount')); // total amount at home before invading
@@ -316,6 +340,13 @@
                     var unitDP = parseFloat($(this).data('dp'));
                     var amountToSend = parseInt($(this).val() || 0);
                     var needBoat = !!$(this).data('need-boat');
+
+                    var totalUnitOP = amountToSend * unitOP * OPMultiplier;
+                    var totalUnitDP = amountToSend * unitDP * DPMultiplier;
+                    var unitSlot = parseInt($(this).data('slot'));
+                    var unitStatsElement = $('#unit' + unitSlot + '_stats');
+                    unitStatsElement.find('.op').text(totalUnitOP.toLocaleString(undefined, {maximumFractionDigits: 2}));
+                    unitStatsElement.find('.dp').text(totalUnitDP.toLocaleString(undefined, {maximumFractionDigits: 2}));
 
                     if (amountToSend === 0) {
                         return true; // continue
@@ -400,7 +431,7 @@
                 } else {
                     invadeButtonElement.removeAttr('disabled');
                 }
-            });
+            }
         })(jQuery);
 
         function select2Template(state) {

--- a/app/routes/api.php
+++ b/app/routes/api.php
@@ -5,32 +5,34 @@ use Illuminate\Routing\Router;
 /** @var Router $router */
 $router->group(['prefix' => 'v1', 'as' => 'api.'], function (Router $router) {
 
-    $router->get('pbbg', function () {
-        return [
-            'name' => 'OpenDominion',
-            'version' => (Cache::get('version') ?? 'unknown'),
-            'description' => 'A text-based, persistent browser-based strategy game (PBBG) in a fantasy war setting',
-            'tags' => ['fantasy', 'multiplayer', 'strategy'],
-            'status' => 'up',
-            'dates' => [
-                'born' => '2013-02-04',
-                'updated' => (Cache::has('version-date') ? carbon(Cache::get('version-date'))->format('Y-m-d') : null),
-            ],
-            'players' => [
-                'registered' => \OpenDominion\Models\User::whereActivated(true)->count(),
-                'active' => \OpenDominion\Models\Dominion::whereHas('round', function ($q) {
-                    $q->where('start_date', '<=', now())
-                        ->where('end_date', '>', now());
-                })->count(),
-            ],
-            'links' => [
-                'beta' => 'https://beta.opendominion.net',
-                'github' => 'https://github.com/WaveHack/OpenDominion',
-            ],
-        ];
+    $router->group(['middleware' => ['throttle:60,1']], function (Router $router) {
+        $router->get('pbbg', function () {
+            return [
+                'name' => 'OpenDominion',
+                'version' => (Cache::get('version') ?? 'unknown'),
+                'description' => 'A text-based, persistent browser-based strategy game (PBBG) in a fantasy war setting',
+                'tags' => ['fantasy', 'multiplayer', 'strategy'],
+                'status' => 'up',
+                'dates' => [
+                    'born' => '2013-02-04',
+                    'updated' => (Cache::has('version-date') ? carbon(Cache::get('version-date'))->format('Y-m-d') : null),
+                ],
+                'players' => [
+                    'registered' => \OpenDominion\Models\User::whereActivated(true)->count(),
+                    'active' => \OpenDominion\Models\Dominion::whereHas('round', function ($q) {
+                        $q->where('start_date', '<=', now())
+                            ->where('end_date', '>', now());
+                    })->count(),
+                ],
+                'links' => [
+                    'beta' => 'https://beta.opendominion.net',
+                    'github' => 'https://github.com/WaveHack/OpenDominion',
+                ],
+            ];
+        });
     });
 
-    $router->group(['prefix' => 'dominion', 'middleware' => ['web', 'auth'], 'as' => 'dominion.'], function (Router $router) {
+    $router->group(['prefix' => 'dominion', 'middleware' => ['web', 'auth', 'dominionselected'], 'as' => 'dominion.'], function (Router $router) {
         $router->get('invasion')->uses('Dominion\APIController@calculateInvasion')->name('invasion');
     });
 

--- a/app/routes/api.php
+++ b/app/routes/api.php
@@ -3,7 +3,7 @@
 use Illuminate\Routing\Router;
 
 /** @var Router $router */
-$router->group(['prefix' => 'v1'], function (Router $router) {
+$router->group(['prefix' => 'v1', 'as' => 'api.'], function (Router $router) {
 
     $router->get('pbbg', function () {
         return [
@@ -28,6 +28,10 @@ $router->group(['prefix' => 'v1'], function (Router $router) {
                 'github' => 'https://github.com/WaveHack/OpenDominion',
             ],
         ];
+    });
+
+    $router->group(['prefix' => 'dominion', 'middleware' => ['web', 'auth'], 'as' => 'dominion.'], function (Router $router) {
+        $router->get('invasion')->uses('Dominion\APIController@calculateInvasion')->name('invasion');
     });
 
 });

--- a/app/routes/api.php
+++ b/app/routes/api.php
@@ -5,7 +5,7 @@ use Illuminate\Routing\Router;
 /** @var Router $router */
 $router->group(['prefix' => 'v1', 'as' => 'api.'], function (Router $router) {
 
-    $router->group(['middleware' => ['throttle:60,1']], function (Router $router) {
+    $router->group(['middleware' => ['bindings', 'throttle:60,1']], function (Router $router) {
         $router->get('pbbg', function () {
             return [
                 'name' => 'OpenDominion',
@@ -32,7 +32,7 @@ $router->group(['prefix' => 'v1', 'as' => 'api.'], function (Router $router) {
         });
     });
 
-    $router->group(['prefix' => 'dominion', 'middleware' => ['web', 'auth', 'dominionselected'], 'as' => 'dominion.'], function (Router $router) {
+    $router->group(['prefix' => 'dominion', 'middleware' => ['api', 'auth', 'dominionselected'], 'as' => 'dominion.'], function (Router $router) {
         $router->get('invasion')->uses('Dominion\APIController@calculateInvasion')->name('invasion');
     });
 

--- a/src/Calculators/Dominion/Actions/RezoningCalculator.php
+++ b/src/Calculators/Dominion/Actions/RezoningCalculator.php
@@ -3,6 +3,7 @@
 namespace OpenDominion\Calculators\Dominion\Actions;
 
 use OpenDominion\Calculators\Dominion\LandCalculator;
+use OpenDominion\Calculators\Dominion\SpellCalculator;
 use OpenDominion\Models\Dominion;
 
 class RezoningCalculator
@@ -10,14 +11,20 @@ class RezoningCalculator
     /** @var LandCalculator */
     protected $landCalculator;
 
+    /** @var SpellCalculator */
+    protected $spellCalculator;
+
     /**
      * RezoningCalculator constructor.
      *
      * @param LandCalculator $landCalculator
      */
-    public function __construct(LandCalculator $landCalculator)
+    public function __construct(
+        LandCalculator $landCalculator,
+        SpellCalculator $spellCalculator)
     {
         $this->landCalculator = $landCalculator;
+        $this->spellCalculator = $spellCalculator;
     }
 
     /**

--- a/src/Calculators/Dominion/MilitaryCalculator.php
+++ b/src/Calculators/Dominion/MilitaryCalculator.php
@@ -334,7 +334,7 @@ class MilitaryCalculator
         return ($this->getDefensivePowerRaw($dominion) / $this->landCalculator->getTotalLand($dominion));
     }
 
-    protected function getUnitPowerWithPerks(Dominion $dominion, string $opposingForceRaceName, float $landRatio, Unit $unit, string $powerType): float
+    public function getUnitPowerWithPerks(Dominion $dominion, string $opposingForceRaceName = null, float $landRatio = null, Unit $unit, string $powerType): float
     {
         $unitPower = $unit->{"power_$powerType"};
 
@@ -418,7 +418,7 @@ class MilitaryCalculator
         return $powerFromPerk;
     }
 
-    protected function getUnitPowerFromStaggeredLandRangePerk(Dominion $dominion, float $landRatio, Unit $unit, string $powerType): float
+    protected function getUnitPowerFromStaggeredLandRangePerk(Dominion $dominion, float $landRatio = null, Unit $unit, string $powerType): float
     {
         $staggeredLandRangePerk = $dominion->race->getUnitPerkValueForUnitSlot(
             $unit->slot,
@@ -436,7 +436,7 @@ class MilitaryCalculator
 
         foreach ($staggeredLandRangePerk as $rangePerk) {
             $range = ((int)$rangePerk[0]) / 100;
-            $power = (int)$rangePerk[1];
+            $power = (float)$rangePerk[1];
 
             if($range > $landRatio) { // TODO: Check this, might be a bug here
                 continue;
@@ -448,7 +448,7 @@ class MilitaryCalculator
         return $powerFromPerk;
     }
 
-    protected function getUnitPowerFromVersusRacePerk(Dominion $dominion, string $opposingForceRaceName, Unit $unit, string $powerType): float
+    protected function getUnitPowerFromVersusRacePerk(Dominion $dominion, string $opposingForceRaceName = null, Unit $unit, string $powerType): float
     {
         $raceNameFormatted = strtolower($opposingForceRaceName);
         $raceNameFormatted = str_replace(' ', '_', $raceNameFormatted);
@@ -479,7 +479,7 @@ class MilitaryCalculator
      * @param Dominion $dominion
      * @return float
      */
-    public function getSpyRatio(Dominion $dominion, string $type): float
+    public function getSpyRatio(Dominion $dominion, string $type = 'offense'): float
     {
         return ($this->getSpyRatioRaw($dominion, $type) * $this->getSpyRatioMultiplier($dominion));
     }
@@ -490,7 +490,7 @@ class MilitaryCalculator
      * @param Dominion $dominion
      * @return float
      */
-    public function getSpyRatioRaw(Dominion $dominion, string $type): float
+    public function getSpyRatioRaw(Dominion $dominion, string $type = 'offense'): float
     {
         $spies = $dominion->military_spies;
 
@@ -552,7 +552,7 @@ class MilitaryCalculator
      * @param Dominion $dominion
      * @return float
      */
-    public function getWizardRatio(Dominion $dominion, string $type): float
+    public function getWizardRatio(Dominion $dominion, string $type = 'offense'): float
     {
         return ($this->getWizardRatioRaw($dominion, $type) * $this->getWizardRatioMultiplier($dominion));
     }
@@ -563,7 +563,7 @@ class MilitaryCalculator
      * @param Dominion $dominion
      * @return float
      */
-    public function getWizardRatioRaw(Dominion $dominion, string $type): float
+    public function getWizardRatioRaw(Dominion $dominion, string $type = 'offense'): float
     {
         $wizards = $dominion->military_wizards + ($dominion->military_archmages * 2);
 

--- a/src/Helpers/RaceHelper.php
+++ b/src/Helpers/RaceHelper.php
@@ -22,6 +22,32 @@ class RaceHelper
 </p>
 DWARF;
 
+        $descriptions['firewalker'] = <<<FIREWALKER
+<p>Beings of pure fire, which came into this world after a powerful sorcerer once got too greedy with their pyro experimentation projects.</p>
+<p>Excellent at proliferation, these fiery beasts seem highly interested in leaving only ash in their wake.</p>
+<p class="text-green">
+    Increased max population<br>
+    Increased gem production<br>
+    Reduced construction costs<br>
+    <span class="text-red">
+        Reduced lumber production
+    </span>
+</p>
+FIREWALKER;
+        // todo: ^ span in p? hacky hacky, move to yml pls
+
+        $descriptions['gnome'] = <<<GNOME
+<p>Placeholder description.</p>
+<p class="text-green">
+    Increased attack strength<br>
+    Decreased food consumption<br>
+    Increased gem production<br>
+    <span class="text-red">
+        Decreased max population
+    </span>
+</p>
+GNOME;
+
         $descriptions['halfling'] = <<<HALFLING
 <p>Placeholder description.</p>
 <p class="text-green">
@@ -47,20 +73,6 @@ HUMAN;
 </p>
 SYLVAN;
 
-        $descriptions['firewalker'] = <<<FIREWALKER
-<p>Beings of pure fire, which came into this world after a powerful sorcerer once got too greedy with their pyro experimentation projects.</p>
-<p>Excellent at proliferation, these fiery beasts seem highly interested in leaving only ash in their wake.</p>
-<p class="text-green">
-    Increased max population<br>
-    Increased gem production<br>
-    Reduced construction costs<br>
-    <span class="text-red">
-        Reduced lumber production
-    </span>
-</p>
-FIREWALKER;
-        // todo: ^ span in p? hacky hacky, move to yml pls
-
         // Evil races
 
         $descriptions['darkelf'] = <<<DARKELF
@@ -82,13 +94,17 @@ DARKELF;
 </p>
 GOBLIN;
 
-        $descriptions['nomad'] = <<<NOMAD
-<p>Descendants of Humans, these folk have been exiled from the kingdom long ago and went their own way.</p>
-<p>Acclimated to the desert life, these traveling Nomads teamed up with the evil races out of spite towards the Humans and their allies.</p>
+        $descriptions['icekin'] = <<<ICEKIN
+<p>Placeholder description.</p>
 <p class="text-green">
-    Increased mana production
+    Increased platinum production<br>
+    Decreased food consumption<br>
+    Decreased Archmage cost<br>
+    <span class="text-red">
+        Decreased lumber production
+    </span>
 </p>
-NOMAD;
+ICEKIN;
 
         $descriptions['lizardfolk'] = <<<LIZARDFOLK
 <p>These amphibious creatures hail from the depths of the seas, having remained mostly hidden for decades before resurfacing and joining the war.</p>
@@ -100,6 +116,26 @@ NOMAD;
     No boats needed
 </p>
 LIZARDFOLK;
+
+        $descriptions['nomad'] = <<<NOMAD
+<p>Descendants of Humans, these folk have been exiled from the kingdom long ago and went their own way.</p>
+<p>Acclimated to the desert life, these traveling Nomads teamed up with the evil races out of spite towards the Humans and their allies.</p>
+<p class="text-green">
+    Increased mana production
+</p>
+NOMAD;
+
+        $descriptions['troll'] = <<<TROLL
+<p>Placeholder description.</p>
+<p class="text-green">
+    Increased attack strength<br>
+    <span class="text-red">
+        Reduced max population<br>
+        Increased food consumption<br>
+        Decreased spy strength
+    </span>
+</p>
+TROLL;
 
         $key = strtolower($race->name);
 

--- a/src/Helpers/RaceHelper.php
+++ b/src/Helpers/RaceHelper.php
@@ -75,7 +75,7 @@ SYLVAN;
 
         // Evil races
 
-        $descriptions['darkelf'] = <<<DARKELF
+        $descriptions['dark elf'] = <<<DARKELF
 <p>Placeholder description.</p>
 <p class="text-green">
     Increased mana population<br>

--- a/src/Http/Controllers/DebugController.php
+++ b/src/Http/Controllers/DebugController.php
@@ -63,7 +63,7 @@ class DebugController extends AbstractDominionController
                 $value = $class->$method();
                 $label = ('[REFACTOR] ' . $label);
 
-            } elseif (in_array($reflectionMethod->getName(), ['getDefensivePower', 'getDefensivePowerMultiplier'])) {
+            } elseif (in_array($reflectionMethod->getName(), ['getOffensivePower', 'getOffensivePowerRaw', 'getDefensivePower', 'getDefensivePowerRaw', 'getDefensivePowerMultiplier', 'getSpyRatio', 'getSpyRatioRaw', 'getWizardRatio', 'getWizardRatioRaw'])) {
                 // Exception for methods which have more than 1 arguments
                 $value = $class->$method(static::$selectedDominion);
 

--- a/src/Http/Controllers/Dominion/APIController.php
+++ b/src/Http/Controllers/Dominion/APIController.php
@@ -4,11 +4,9 @@ namespace OpenDominion\Http\Controllers\Dominion;
 
 use Illuminate\Http\Request;
 use OpenDominion\Calculators\Dominion\MilitaryCalculator;
-/*use OpenDominion\Calculators\Dominion\RangeCalculator;
-use OpenDominion\Helpers\UnitHelper;*/
+use OpenDominion\Http\Requests\Dominion\API\InvadeCalculationRequest;
 use OpenDominion\Models\Dominion;
 use OpenDominion\Services\Dominion\API\InvadeCalculationService;
-use OpenDominion\Http\Requests\Dominion\API\InvadeCalculationRequest;
 use Throwable;
 
 class APIController extends AbstractDominionController

--- a/src/Http/Controllers/Dominion/APIController.php
+++ b/src/Http/Controllers/Dominion/APIController.php
@@ -5,24 +5,32 @@ namespace OpenDominion\Http\Controllers\Dominion;
 use Illuminate\Http\Request;
 use OpenDominion\Calculators\Dominion\MilitaryCalculator;
 /*use OpenDominion\Calculators\Dominion\RangeCalculator;
-use OpenDominion\Helpers\UnitHelper;
+use OpenDominion\Helpers\UnitHelper;*/
 use OpenDominion\Models\Dominion;
-use OpenDominion\Services\Dominion\Actions\InvadeActionService;
-use OpenDominion\Services\Dominion\ProtectionService;*/
+use OpenDominion\Services\Dominion\API\InvadeCalculationService;
+use OpenDominion\Http\Requests\Dominion\API\InvadeCalculationRequest;
 use Throwable;
 
 class APIController extends AbstractDominionController
 {
-    public function calculateInvasion(Request $request)
+    public function calculateInvasion(InvadeCalculationRequest $request)
     {
-        $input = [
-            'target' => $request->get('target_dominion'),
-            'unit1' => $request->get('unit1'),
-            'unit2' => $request->get('unit2'),
-            'unit3' => $request->get('unit3'),
-            'unit4' => $request->get('unit4')
-        ];
+        $dominion = $this->getSelectedDominion();
+        $invadeCalculationService = app(InvadeCalculationService::class);
 
-        return $input;
+        try {
+            $result = $invadeCalculationService->calculate(
+                $dominion,
+                Dominion::find($request->get('target_dominion')),
+                $request->get('unit')
+            );
+        } catch (Throwable $e) {
+            return [
+                'result' => 'error',
+                'errors' => [$e->getMessage()]
+            ];
+        }
+
+        return $result;
     }
 }

--- a/src/Http/Controllers/Dominion/APIController.php
+++ b/src/Http/Controllers/Dominion/APIController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace OpenDominion\Http\Controllers\Dominion;
+
+use Illuminate\Http\Request;
+use OpenDominion\Calculators\Dominion\MilitaryCalculator;
+/*use OpenDominion\Calculators\Dominion\RangeCalculator;
+use OpenDominion\Helpers\UnitHelper;
+use OpenDominion\Models\Dominion;
+use OpenDominion\Services\Dominion\Actions\InvadeActionService;
+use OpenDominion\Services\Dominion\ProtectionService;*/
+use Throwable;
+
+class APIController extends AbstractDominionController
+{
+    public function calculateInvasion(Request $request)
+    {
+        $input = [
+            'target' => $request->get('target_dominion'),
+            'unit1' => $request->get('unit1'),
+            'unit2' => $request->get('unit2'),
+            'unit3' => $request->get('unit3'),
+            'unit4' => $request->get('unit4')
+        ];
+
+        return $input;
+    }
+}

--- a/src/Http/Kernel.php
+++ b/src/Http/Kernel.php
@@ -42,7 +42,6 @@ class Kernel extends HttpKernel
         ],
 
         'api' => [
-            'throttle:60,1',
             'bindings',
         ],
     ];

--- a/src/Http/Kernel.php
+++ b/src/Http/Kernel.php
@@ -42,7 +42,13 @@ class Kernel extends HttpKernel
         ],
 
         'api' => [
-            'bindings',
+            Middleware\EncryptCookies::class,
+            \Illuminate\Session\Middleware\StartSession::class,
+            \Illuminate\Session\Middleware\AuthenticateSession::class,
+            \Illuminate\View\Middleware\ShareErrorsFromSession::class,
+            \Illuminate\Routing\Middleware\SubstituteBindings::class,
+
+            Middleware\ShareSelectedDominion::class,
         ],
     ];
 

--- a/src/Http/Requests/Dominion/API/InvadeCalculationRequest.php
+++ b/src/Http/Requests/Dominion/API/InvadeCalculationRequest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace OpenDominion\Http\Requests\Dominion\Actions;
+namespace OpenDominion\Http\Requests\Dominion\API;
 
 use OpenDominion\Http\Requests\Dominion\AbstractDominionRequest;
 
-class InvadeActionRequest extends AbstractDominionRequest
+class InvadeCalculationRequest extends AbstractDominionRequest
 {
     /**
      * {@inheritdoc}
@@ -12,7 +12,7 @@ class InvadeActionRequest extends AbstractDominionRequest
     public function rules()
     {
         return [
-            'target_dominion' => 'required|integer',
+            'target_dominion' => 'nullable|integer',
             'unit' => 'nullable|array',
         ];
     }

--- a/src/Providers/RouteServiceProvider.php
+++ b/src/Providers/RouteServiceProvider.php
@@ -73,7 +73,6 @@ class RouteServiceProvider extends ServiceProvider
     protected function mapApiRoutes()
     {
         Route::prefix('api')
-            ->middleware('api')
             ->namespace($this->namespace)
             ->group(base_path('app/routes/api.php'));
     }

--- a/src/Services/Dominion/API/InvadeCalculationService.php
+++ b/src/Services/Dominion/API/InvadeCalculationService.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace OpenDominion\Services\Dominion\API;
+
+//use OpenDominion\Calculators\Dominion\BuildingCalculator;
+//use OpenDominion\Calculators\Dominion\CasualtiesCalculator;
+//use OpenDominion\Calculators\Dominion\LandCalculator;
+use OpenDominion\Calculators\Dominion\MilitaryCalculator;
+use OpenDominion\Calculators\Dominion\RangeCalculator;
+//use OpenDominion\Calculators\Dominion\SpellCalculator;
+use OpenDominion\Models\Dominion;
+//use OpenDominion\Models\Unit;
+use RuntimeException;
+use Throwable;
+
+class InvadeCalculationService
+{
+    /**
+     * @var int How many units can fit in a single boat
+     */
+    protected const UNITS_PER_BOAT = 30;
+
+    /** @var BuildingCalculator */
+    //protected $buildingCalculator;
+
+    /** @var LandCalculator */
+    //protected $landCalculator;
+
+    /** @var MilitaryCalculator */
+    protected $militaryCalculator;
+
+    /** @var RangeCalculator */
+    protected $rangeCalculator;
+
+    /** @var SpellCalculator */
+    //protected $spellCalculator;
+
+    /** @var array Calculation result array. */
+    protected $calculationResult = [
+        'result' => 'success',
+        'boats_needed' => 0,
+        'dp_multiplier' => null,
+        'op_multiplier' => null,
+        'land_ratio' => 0.5,
+        'spell_bonus' => null,
+        'units' => [ // home, away, raw OP, raw DP
+            '1' => ['dp' => 0, 'op' => 0],
+            '2' => ['dp' => 0, 'op' => 0],
+            '3' => ['dp' => 0, 'op' => 0],
+            '4' => ['dp' => 0, 'op' => 0],
+        ],
+    ];
+
+    /**
+     * InvadeActionService constructor.
+     *
+     * @param BuildingCalculator $buildingCalculator
+     * @param LandCalculator $landCalculator
+     * @param MilitaryCalculator $militaryCalculator
+     * @param RangeCalculator $rangeCalculator
+     * @param SpellCalculator $spellCalculator
+     */
+    public function __construct(
+        //BuildingCalculator $buildingCalculator,
+        //LandCalculator $landCalculator,
+        MilitaryCalculator $militaryCalculator,
+        RangeCalculator $rangeCalculator
+        //SpellCalculator $spellCalculator
+        )
+    {
+        //$this->buildingCalculator = $buildingCalculator;
+        //$this->landCalculator = $landCalculator;
+        $this->militaryCalculator = $militaryCalculator;
+        $this->rangeCalculator = $rangeCalculator;
+        //$this->spellCalculator = $spellCalculator;
+    }
+
+    /**
+     * Calculates an invasion against dominion $target from $dominion.
+     *
+     * @param Dominion $dominion
+     * @param Dominion $target
+     * @param array $units
+     * @return array
+     * @throws Throwable
+     */
+    public function calculate(Dominion $dominion, Dominion $target = null, array $units): array
+    {
+        // Sanitize input
+        $units = array_map('intval', array_filter($units));
+
+        //if (!$this->hasEnoughBoats($dominion, $units)) {
+        //    throw new RuntimeException('You do not have enough boats to send this many units');
+        //}
+
+        if($target) {
+            $landRatio = $this->rangeCalculator->getDominionRange($dominion, $target) / 100;
+            $this->calculationResult['land_ratio'] = $landRatio;
+            $opposingForceRaceName = $target->race->name;
+        } else {
+            $landRatio = 0.5;
+            $opposingForceRaceName = null;
+        }
+
+        $this->calculationResult['dp_multiplier'] = $this->militaryCalculator->getDefensivePowerMultiplier($dominion);
+        $this->calculationResult['op_multiplier'] = $this->militaryCalculator->getOffensivePowerMultiplier($dominion);
+
+        foreach ($dominion->race->units as $unit) {
+            $this->calculationResult['units'][$unit->slot]['dp'] = $this->militaryCalculator->getUnitPowerWithPerks($dominion, $opposingForceRaceName, $landRatio, $unit, 'defense');
+            $this->calculationResult['units'][$unit->slot]['op'] = $this->militaryCalculator->getUnitPowerWithPerks($dominion, $opposingForceRaceName, $landRatio, $unit, 'offense');
+        }
+
+        return $this->calculationResult;
+    }
+}

--- a/tests/Feature/TickTest.php
+++ b/tests/Feature/TickTest.php
@@ -216,7 +216,9 @@ class TickTest extends AbstractBrowserKitTestCase
         $this->seedDatabase();
         $user = $this->createUser();
         $round = $this->createRound();
-        $dominion = $this->createDominion($user, $round);
+        // don't use a race that has food-related perks
+        $race = \OpenDominion\Models\Race::where('name', 'Human')->first();
+        $dominion = $this->createDominion($user, $round, $race);
 
         $productionCalculator = $this->app->make(ProductionCalculator::class);
         $spellActionService = $this->app->make(SpellActionService::class);


### PR DESCRIPTION
Features
- Adds new API route group with invasion calculator endpoint.
- Connected to existing frontend code with minimal changes.
- Updates unit OP/DP onload and when selecting a target.
- Takes into account building/land-based perks as well as target range/race perks.

Bugfixes
- Errors with default value of opposingForceRaceName
- Errors with RezoningCalculator constructor  
- Errors with multi-argument functions in DebugController
- Update validation for InvadeActionServiceRequest
- reverse order of offense_staggered_land_range (Dark Elf/Gnome)
- correct indentation on need_boats (Dark Elf)
- correct typo in perk (Dark Elf)

Todo
- Should be refactored a bit in the future to do most/all of the calculations on the backend.