### PR TITLE
Additional work on Clairvoyance

### DIFF
--- a/app/database/migrations/2019_06_02_193607_add_target_realm_id_to_info_ops_table.php
+++ b/app/database/migrations/2019_06_02_193607_add_target_realm_id_to_info_ops_table.php
@@ -14,6 +14,7 @@ class AddTargetRealmIdToInfoOpsTable extends Migration
     public function up()
     {
         Schema::table('info_ops', function (Blueprint $table) {
+            $table->integer('target_realm_id')->unsigned()->nullable();
             $table->foreign('target_realm_id')->references('id')->on('realms');
         });
     }

--- a/app/resources/views/pages/dominion/op-center/index.blade.php
+++ b/app/resources/views/pages/dominion/op-center/index.blade.php
@@ -93,6 +93,61 @@
                     </table>
                 </div>
             </div>
+
+            <div class="box box-primary">
+                <div class="box-header">
+                    <h3 class="box-title">Town Crier</h3>
+                </div>
+                <div class="box-body table-responsive">
+                    <table class="table table-hover" id="dominions-table">
+                        <colgroup>
+                            <col>
+                            <col>
+                            <col width="200">
+                        </colgroup>
+                        <thead>
+                            <tr>
+                                <th>Realm</th>
+                                <th>Target</th>
+                                <th class="text-center">Taken</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach ($clairvoyanceRealms as $realm)
+                                @php
+                                    $lastInfoOp = $infoOpService->getLastClairvoyance($selectedDominion->realm, $realm);
+                                @endphp
+                                @if ($lastInfoOp->isInvalid())
+                                    @continue
+                                @endif
+                                <tr>
+                                    <td data-order="{{ $realm->number }}">
+                                        <a href="{{ route('dominion.op-center.clairvoyance', $realm->number) }}">{{ $realm->name }} (#{{ $realm->number }})</a>
+                                    </td>
+                                    <td data-order="{{ $lastInfoOp->targetDominion->name }}">
+                                        <a href="{{ route('dominion.op-center.show', $lastInfoOp->targetDominion) }}">{{ $lastInfoOp->targetDominion->name }}</a>
+                                    </td>
+                                    <td class="text-center" data-search="" data-order="{{ $lastInfoOp->updated_at->getTimestamp() }}">
+                                        Clairvoyance by
+                                        @if ($lastInfoOp->sourceDominion->id === $selectedDominion->id)
+                                            <strong>
+                                                {{ $selectedDominion->name }}
+                                            </strong>
+                                        @else
+                                            {{ $lastInfoOp->sourceDominion->name }}
+                                        @endif
+                                        <br>
+                                        <span class="small">
+                                            {{ $lastInfoOp->updated_at->diffForHumans() }}
+                                        </span>
+                                    </td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+
         </div>
 
         <div class="col-sm-12 col-md-3">

--- a/app/resources/views/pages/dominion/op-center/show.blade.php
+++ b/app/resources/views/pages/dominion/op-center/show.blade.php
@@ -814,6 +814,41 @@
                 @endif
             @endcomponent
         </div>
+    </div>
+
+    <div class="row">
+        <div class="col-sm-12 col-sm-6">
+            @component('partials.dominion.op-center.box')
+                @php
+                    $infoOp = $infoOpService->getInfoOp($selectedDominion->realm, $dominion, 'clairvoyance');
+                @endphp
+
+                @slot('title', 'Town Crier')
+                @slot('titleIconClass', 'fa fa-newspaper-o')
+
+                @if ($infoOp === null)
+                    <p>No recent data available.</p>
+                    <p>Cast magic spell 'Clairvoyance' to reveal information.</p>
+                @else
+                    <a href="{{ route('dominion.op-center.clairvoyance', $dominion->realm->id) }}">{{ $dominion->realm->name }} (#{{ $dominion->realm->number }})</a>
+                    - <em>Revealed <abbr title="{{ $infoOp->updated_at }}">{{ $infoOp->updated_at->diffForHumans() }}</abbr> by {{ $infoOp->sourceDominion->name }}</em>
+                    @if ($infoOp->isStale())
+                        <span class="label label-warning">Stale</span>
+                    @endif
+                @endif
+
+                @slot('boxFooter')
+                    <div class="pull-right">
+                        <form action="{{ route('dominion.magic') }}" method="post" role="form">
+                            @csrf
+                            <input type="hidden" name="target_dominion" value="{{ $dominion->id }}">
+                            <input type="hidden" name="spell" value="clairvoyance">
+                            <button type="submit" class="btn btn-sm btn-primary">Clairvoyance ({{ number_format($spellCalculator->getManaCost($selectedDominion, 'clairvoyance')) }} mana)</button>
+                        </form>
+                    </div>
+                @endslot
+            @endcomponent
+        </div>
 
     </div>
 @endsection

--- a/app/resources/views/pages/dominion/town-crier.blade.php
+++ b/app/resources/views/pages/dominion/town-crier.blade.php
@@ -4,11 +4,12 @@
 
 @section('content')
     <div class="row">
-
         <div class="col-sm-12 col-md-9">
             <div class="box box-primary">
                 <div class="box-header with-border">
-                    <h3 class="box-title"><i class="fa fa-newspaper-o"></i> Town Crier for {{ $realm->name }} (#{{ $realm->number }})</h3>
+                    <h3 class="box-title">
+                        <i class="fa fa-newspaper-o"></i> Town Crier for {{ $realm->name }} (#{{ $realm->number }})
+                    </h3>
                 </div>
 
                 @if ($gameEvents->isEmpty())
@@ -17,7 +18,6 @@
                     </div>
                 @else
                     <div class="box-body table-responsive no-padding">
-
                         <table class="table table-striped">
                             <colgroup>
                                 <col>
@@ -63,7 +63,11 @@
                                             @endif
                                         </td>
                                         <td class="text-center">
-                                            <a href="{{ route('dominion.event', [$gameEvent->id]) }}">Link</a>
+                                            @if ($gameEvent->source->realm_id == $selectedDominion->realm->id)
+                                                <a href="{{ route('dominion.event', [$gameEvent->id]) }}">Link</a>
+                                            @else
+                                                --
+                                            @endif
                                         </td>
                                         <td class="text-center">
                                             <span title="{{ $gameEvent->created_at }}">{{ $gameEvent->created_at->diffForHumans() }}</span>
@@ -72,7 +76,11 @@
                                 @endforeach
                             </tbody>
                         </table>
-
+                        @if ($fromOpCenter)
+                            <div class="box-footer">
+                                <em>Revealed <abbr title="{{ $clairvoyanceInfoOp->updated_at }}">{{ $clairvoyanceInfoOp->updated_at->diffForHumans() }}</abbr> by {{ $clairvoyanceInfoOp->sourceDominion->name }}</em>
+                            </div>
+                        @endif
                     </div>
                 @endif
             </div>

--- a/app/routes/web.php
+++ b/app/routes/web.php
@@ -141,6 +141,7 @@ $router->group(['middleware' => 'auth'], function (Router $router) {
             // Op Center
             $router->get('op-center')->uses('Dominion\OpCenterController@getIndex')->name('op-center');
             $router->get('op-center/{dominion}')->uses('Dominion\OpCenterController@getDominion')->name('op-center.show');
+            $router->get('op-center/clairvoyance/{realmNumber}')->uses('Dominion\OpCenterController@getClairvoyance')->name('op-center.clairvoyance');
 
             // Rankings
             $router->get('rankings/{type?}')->uses('Dominion\RankingsController@getRankings')->name('rankings');

--- a/src/Helpers/SpellHelper.php
+++ b/src/Helpers/SpellHelper.php
@@ -63,7 +63,7 @@ class SpellHelper
             return $spell['races']->contains($raceName);
         })->first();
 
-        return collect([
+        return collect(array_filter([
             [
                 'name' => 'Gaia\'s Watch',
                 'description' => '+10% food production',
@@ -122,7 +122,7 @@ class SpellHelper
 //                'cooldown' => 22, // todo
 //            ],
             $racialSpell
-        ]);
+        ]));
     }
 
     public function getRacialSelfSpells(): Collection

--- a/src/Http/Controllers/Dominion/OpCenterController.php
+++ b/src/Http/Controllers/Dominion/OpCenterController.php
@@ -26,7 +26,7 @@ class OpCenterController extends AbstractDominionController
             ->map(
                 function ($infoOp)
                 {
-                    return $infoOp->realm;
+                    return $infoOp->targetRealm;
                 }
             );
 
@@ -61,29 +61,28 @@ class OpCenterController extends AbstractDominionController
         ]);
     }
 
-    public function getClairvoyance(Realm $targetRealm)
+    public function getClairvoyance(int $realmNumber)
     {
         $infoOpService = app(InfoOpService::class);
+        $targetRealm = Realm::findOrFail($realmNumber);
 
         $clairvoyanceInfoOp = $infoOpService->getInfoOpForRealm($this->getSelectedDominion()->realm, $targetRealm, 'clairvoyance');
 
         if($clairvoyanceInfoOp == null)
         {
-            // throw?
+            abort(404);
         }
 
         $gameEventService = app(GameEventService::class);
-
-        $clairvoyanceUpdateAt = $clairvoyanceInfoOp->updated_at;
-        $clairvoyanceData = $gameEventService->getClairvoyance($targetRealm, $clairvoyanceUpdateAt);
+        $clairvoyanceData = $gameEventService->getClairvoyance($targetRealm, $clairvoyanceInfoOp->updated_at);
 
         $gameEvents = $clairvoyanceData['gameEvents'];
         $dominionIds = $clairvoyanceData['dominionIds'];
 
         return view('pages.dominion.town-crier', compact(
             'gameEvents',
-            'targetRealm',
-            'dominionIds'
-        ));
+            'dominionIds',
+            'clairvoyanceInfoOp'
+        ))->with('realm', $targetRealm)->with('fromOpCenter', true);
     }
 }

--- a/src/Http/Controllers/Dominion/TownCrierController.php
+++ b/src/Http/Controllers/Dominion/TownCrierController.php
@@ -11,6 +11,7 @@ class TownCrierController extends AbstractDominionController
         $gameEventService = app(GameEventService::class);
 
         $dominion = $this->getSelectedDominion();
+        $realm = $dominion->realm;
 
         $townCrierData = $gameEventService->getTownCrier($dominion);
 
@@ -21,6 +22,6 @@ class TownCrierController extends AbstractDominionController
             'gameEvents',
             'realm',
             'dominionIds'
-        ));
+        ))->with('fromOpCenter', false);
     }
 }

--- a/src/Models/InfoOp.php
+++ b/src/Models/InfoOp.php
@@ -42,7 +42,7 @@ class InfoOp extends AbstractModel
 
     public function targetDominion()
     {
-        //
+        return $this->belongsTo(Dominion::class, 'target_dominion_id');
     }
 
     public function targetRealm()

--- a/src/Services/Dominion/Actions/SpellActionService.php
+++ b/src/Services/Dominion/Actions/SpellActionService.php
@@ -161,7 +161,7 @@ class SpellActionService
                 ],
                 'redirect' =>
                     $this->spellHelper->isInfoOpSpell($spellKey) && $result['success']
-                        ? route('dominion.op-center.show', $target->id)
+                        ? $result['redirect']
                         : null,
             ] + $result;
     }
@@ -363,15 +363,16 @@ class SpellActionService
         $infoOp->updated_at = now(); // todo: fixable with ->save(['touch'])?
         $infoOp->save();
 
+        $redirect = route('dominion.op-center.show', $target);
         if($spellKey === 'clairvoyance') {
-            // redirect somewhere else :D
+            $redirect = route('dominion.op-center.clairvoyance', $target->realm->id);
         }
 
         return [
             'success' => true,
             'message' => 'Your wizards cast the spell successfully, and a wealth of information appears before you.',
             'wizardStrengthCost' => 2,
-            'redirect' => route('dominion.op-center.show', $target),
+            'redirect' => $redirect,
         ];
     }
 


### PR DESCRIPTION
- Separated the clairvoyance ops from the rest in the op center table view / counts.
- Added a link to view/cast clairvoyance from individual dominion op center page (do we like this?)
- Hides links to results when both dominions are out-of-realm.