### PR TITLE
Improve tick performance

### DIFF
--- a/src/Console/Commands/Development/RealmSeederCommand.php
+++ b/src/Console/Commands/Development/RealmSeederCommand.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace OpenDominion\Console\Commands\Development;
+
+use Illuminate\Console\Command;
+use OpenDominion\Console\Commands\CommandInterface;
+use OpenDominion\Factories\RealmFactory;
+use OpenDominion\Models\Dominion;
+use OpenDominion\Models\Race;
+use OpenDominion\Models\Realm;
+use OpenDominion\Models\Round;
+use OpenDominion\Models\User;
+use RuntimeException;
+
+class RealmSeederCommand extends Command implements CommandInterface
+{
+    /** @var string The name and signature of the console command. */
+    protected $signature = 'dev:seed:realms
+                             {--count=20 : Number of realms to fully populate with Faker dominion data}';
+
+    /** @var string The console command description. */
+    protected $description = 'Creates new realms and dominions for testing.';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(): void
+    {
+        $count = $this->option('count');
+
+        if ($count < 0) {
+            throw new RuntimeException('Option --count must be greater than zero.');
+        }
+
+        $round = Round::all()->last();
+        if($round) {
+            $realms = Realm::where('round_id', '=', $round->id)->get();
+            foreach($realms as $realm) {
+                $races = Race::where('alignment', '=', $realm->alignment)->get(['id'])->toArray();
+                $dom_count = Dominion::where('realm_id', $realm->id)->count();
+                $user = factory(User::class, $round->realm_size - $dom_count)->create()->each(function($u) use ($round, $realm, $races) {
+                    factory(Dominion::class)->create([
+                        'user_id' => $u->id,
+                        'round_id' => $round->id,
+                        'realm_id' => $realm->id,
+                        'race_id' => $races[array_rand($races)]['id'],
+                    ]);
+                });
+            }
+            for ($n = count($realms)+1; $n <= $count; $n++) {
+                $alignment = rand(0, 1) ? 'good' : 'evil';
+                $realm = app(RealmFactory::class)->create($round, $alignment);
+                $races = Race::where('alignment', '=', $realm->alignment)->get(['id'])->toArray();
+                $user = factory(User::class, $round->realm_size)->create()->each(function($u) use ($round, $realm, $races) {
+                    factory(Dominion::class)->create([
+                        'user_id' => $u->id,
+                        'round_id' => $round->id,
+                        'realm_id' => $realm->id,
+                        'race_id' => $races[array_rand($races)]['id'],
+                    ]);
+                });
+            }
+        } else {
+            throw new RuntimeException('No rounds found, seed the development database first.');
+        }
+    }
+}

--- a/src/Models/Dominion.php
+++ b/src/Models/Dominion.php
@@ -182,6 +182,11 @@ class Dominion extends AbstractModel
         return $this->hasMany(Dominion\History::class);
     }
 
+    public function queue()
+    {
+        return $this->hasMany(Dominion\Queue::class);
+    }
+
     public function pack()
     {
         return $this->belongsTo(Pack::class);

--- a/src/Models/Dominion/Queue.php
+++ b/src/Models/Dominion/Queue.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace OpenDominion\Models\Dominion;
+
+use OpenDominion\Models\AbstractModel;
+
+/**
+ * OpenDominion\Models\Dominion\Queue
+ *
+ * @property int $id
+ * @property int $dominion_id
+ * @property string $source
+ * @property string $resource
+ * @property int $hours
+ * @property int $amount
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @method static \Illuminate\Database\Eloquent\Builder|\OpenDominion\Models\Dominion\History newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|\OpenDominion\Models\Dominion\History newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|\OpenDominion\Models\Dominion\History query()
+ * @mixin \Eloquent
+ */
+class Queue extends AbstractModel
+{
+    protected $table = 'dominion_queue';
+
+    protected $guarded = ['id', 'created_at'];
+
+    protected $dates = ['created_at'];
+
+    const UPDATED_AT = null;
+}

--- a/src/Services/Dominion/QueueService.php
+++ b/src/Services/Dominion/QueueService.php
@@ -44,10 +44,9 @@ class QueueService
             return collect(array_get($this->queueCache, $cacheKey));
         }
 
-        $data = DB::table('dominion_queue')->where([
-            'dominion_id' => $dominion->id,
-            'source' => $source,
-        ])->get();
+        $data = $dominion->queue->filter(function ($row) use ($source) {
+            return $row->source === $source;
+        });
 
         array_set($this->queueCache, $cacheKey, $data->toArray());
 


### PR DESCRIPTION
These changes group the queries on the dominion_queue table together (reducing queries per dominion by 9-12) and also allows the queue data to be eager loaded.