### PR TITLE
Fix defense calculation for attacking forces

### DIFF
--- a/src/Calculators/Dominion/MilitaryCalculator.php
+++ b/src/Calculators/Dominion/MilitaryCalculator.php
@@ -243,6 +243,10 @@ class MilitaryCalculator
             $dp += ($powerDefense * $numberOfUnits);
         }
 
+        // Attacking Forces skip draftees and land-based defenses
+        if ($units !== null)
+            return $dp;
+
         // Draftees
         if(!$ignoreDraftees) {
             $dp += ($dominion->military_draftees * $dpPerDraftee);


### PR DESCRIPTION
This caused an issue where the frontend would allow you to attack, but backend would incorrectly fail the 5:4 check. Invasion page should eventually pull all of these calculations from the API.