### PR TITLE
Added use of getUnitPowerWithPerk from military calc in nw calc.

### DIFF
--- a/src/Calculators/NetworthCalculator.php
+++ b/src/Calculators/NetworthCalculator.php
@@ -75,7 +75,7 @@ class NetworthCalculator
 
         foreach ($dominion->race->units as $unit) {
             $totalUnitsOfType = $this->militaryCalculator->getTotalUnitsForSlot($dominion, $unit->slot);
-            $networth += $totalUnitsOfType * $this->getUnitNetworth($unit, $dominion);
+            $networth += $totalUnitsOfType * $this->getUnitNetworth($dominion, $unit);
         }
 
         $networth += ($dominion->military_spies * $networthPerSpy);

--- a/src/Calculators/NetworthCalculator.php
+++ b/src/Calculators/NetworthCalculator.php
@@ -104,8 +104,8 @@ class NetworthCalculator
             return 5;
         }
 
-        $unitOffense = $this->militaryCalculator->getUnitPowerWithPerks($dominion, null, 1, $unit, "offense");
-        $unitDefense = $this->militaryCalculator->getUnitPowerWithPerks($dominion, null, 1, $unit, "defense");
+        $unitOffense = $this->militaryCalculator->getUnitPowerWithPerks($dominion, null, 1, $unit, 'offense');
+        $unitDefense = $this->militaryCalculator->getUnitPowerWithPerks($dominion, null, 1, $unit, 'defense');
 
         return (
             (1.8 * min(6, max($unitOffense, $unitDefense)))

--- a/src/Calculators/NetworthCalculator.php
+++ b/src/Calculators/NetworthCalculator.php
@@ -75,7 +75,7 @@ class NetworthCalculator
 
         foreach ($dominion->race->units as $unit) {
             $totalUnitsOfType = $this->militaryCalculator->getTotalUnitsForSlot($dominion, $unit->slot);
-            $networth += $totalUnitsOfType * $this->getUnitNetworth($unit);
+            $networth += $totalUnitsOfType * $this->getUnitNetworth($unit, $dominion);
         }
 
         $networth += ($dominion->military_spies * $networthPerSpy);
@@ -94,19 +94,23 @@ class NetworthCalculator
     /**
      * Returns a single Unit's networth.
      *
+     * @param Dominion $dominion
      * @param Unit $unit
      * @return float
      */
-    public function getUnitNetworth(Unit $unit): float
+    public function getUnitNetworth(Dominion $dominion, Unit $unit): float
     {
         if (in_array($unit->slot, [1, 2], false)) {
             return 5;
         }
 
+        $unitOffense = $this->militaryCalculator->getUnitPowerWithPerks($dominion, null, 1, $unit, "offense");
+        $unitDefense = $this->militaryCalculator->getUnitPowerWithPerks($dominion, null, 1, $unit, "defense");
+
         return (
-            (1.8 * min(6, max($unit->power_offense, $unit->power_defense)))
-            + (0.45 * min(6, min($unit->power_offense, $unit->power_defense)))
-            + (0.2 * (max(($unit->power_offense - 6), 0) + max(($unit->power_defense - 6), 0)))
+            (1.8 * min(6, max($unitOffense, $unitDefense)))
+            + (0.45 * min(6, min($unitOffense, $unitDefense)))
+            + (0.2 * (max(($unitOffense - 6), 0) + max(($unitDefense - 6), 0)))
         );
     }
 }


### PR DESCRIPTION
So, will give max power for land ratio based perks. It will be based on the actual land % for that type of perk. It will not give any extra for vs_race.