### PR TITLE
Adjust line format in Council

### DIFF
--- a/app/config/markdown.php
+++ b/app/config/markdown.php
@@ -63,7 +63,7 @@ return [
     'renderer' => [
         'block_separator' => "\n",
         'inner_separator' => "\n",
-        'soft_break'      => "\n",
+        'soft_break'      => "<br/>",
     ],
 
     /*


### PR DESCRIPTION
Changed markdown config to render soft breaks as browser recognizable <br/> tag instead of a newline.