### PR TITLE
Op Center improvements

### DIFF
--- a/app/database/migrations/2019_06_24_192144_remove_info_ops_source_realm_target_dominion_constraint.php
+++ b/app/database/migrations/2019_06_24_192144_remove_info_ops_source_realm_target_dominion_constraint.php
@@ -18,10 +18,12 @@ class RemoveInfoOpsSourceRealmTargetDominionConstraint extends Migration
             $table->dropForeign(['target_dominion_id']);
             $table->dropUnique(['source_realm_id', 'target_dominion_id', 'type']);
 
+            $table->boolean('latest')->default(true);
+
             $table->foreign('source_realm_id')->references('id')->on('realms');
             $table->foreign('target_dominion_id')->references('id')->on('dominions');
 
-            $table->index(['type']);
+            $table->index(['source_realm_id', 'target_dominion_id', 'latest']);
         });
     }
 
@@ -33,8 +35,15 @@ class RemoveInfoOpsSourceRealmTargetDominionConstraint extends Migration
     public function down()
     {
         Schema::table('info_ops', function (Blueprint $table) {
-            $table->dropIndex(['type']);
+            $table->dropForeign(['source_realm_id']);
+            $table->dropForeign(['target_dominion_id']);
+
+            $table->dropIndex(['source_realm_id', 'target_dominion_id', 'latest']);
+            $table->dropColumn(['latest']);
+
             $table->unique(['source_realm_id', 'target_dominion_id', 'type']);
+            $table->foreign('source_realm_id')->references('id')->on('realms');
+            $table->foreign('target_dominion_id')->references('id')->on('dominions');
         });
     }
 }

--- a/app/database/migrations/2019_06_24_192144_remove_info_ops_source_realm_target_dominion_constraint.php
+++ b/app/database/migrations/2019_06_24_192144_remove_info_ops_source_realm_target_dominion_constraint.php
@@ -23,6 +23,7 @@ class RemoveInfoOpsSourceRealmTargetDominionConstraint extends Migration
             $table->foreign('source_realm_id')->references('id')->on('realms');
             $table->foreign('target_dominion_id')->references('id')->on('dominions');
 
+            $table->index(['source_realm_id', 'target_dominion_id', 'type']);
             $table->index(['source_realm_id', 'target_dominion_id', 'latest']);
         });
     }
@@ -38,6 +39,7 @@ class RemoveInfoOpsSourceRealmTargetDominionConstraint extends Migration
             $table->dropForeign(['source_realm_id']);
             $table->dropForeign(['target_dominion_id']);
 
+            $table->dropIndex(['source_realm_id', 'target_dominion_id', 'type']);
             $table->dropIndex(['source_realm_id', 'target_dominion_id', 'latest']);
             $table->dropColumn(['latest']);
 

--- a/app/database/migrations/2019_06_24_192144_remove_info_ops_source_realm_target_dominion_constraint.php
+++ b/app/database/migrations/2019_06_24_192144_remove_info_ops_source_realm_target_dominion_constraint.php
@@ -14,10 +14,10 @@ class RemoveInfoOpsSourceRealmTargetDominionConstraint extends Migration
     public function up()
     {
         Schema::table('info_ops', function (Blueprint $table) {
-            $table->index(['source_realm_id', 'target_dominion_id', 'type']);
-            $table->index(['source_realm_id', 'target_dominion_id', 'latest']);
             $table->boolean('latest')->default(true);
 
+            $table->index(['source_realm_id']);
+            $table->index(['target_dominion_id']);
             $table->dropUnique(['source_realm_id', 'target_dominion_id', 'type']);
         });
     }
@@ -30,11 +30,11 @@ class RemoveInfoOpsSourceRealmTargetDominionConstraint extends Migration
     public function down()
     {
         Schema::table('info_ops', function (Blueprint $table) {
-            $table->unique(['source_realm_id', 'target_dominion_id', 'type']);
-
-            $table->dropIndex(['source_realm_id', 'target_dominion_id', 'type']);
-            $table->dropIndex(['source_realm_id', 'target_dominion_id', 'latest']);
             $table->dropColumn(['latest']);
+
+            $table->unique(['source_realm_id', 'target_dominion_id', 'type']);
+            $table->dropIndex(['source_realm_id']);
+            $table->dropIndex(['target_dominion_id']);
         });
     }
 }

--- a/app/database/migrations/2019_06_24_192144_remove_info_ops_source_realm_target_dominion_constraint.php
+++ b/app/database/migrations/2019_06_24_192144_remove_info_ops_source_realm_target_dominion_constraint.php
@@ -14,17 +14,11 @@ class RemoveInfoOpsSourceRealmTargetDominionConstraint extends Migration
     public function up()
     {
         Schema::table('info_ops', function (Blueprint $table) {
-            $table->dropForeign(['source_realm_id']);
-            $table->dropForeign(['target_dominion_id']);
-            $table->dropUnique(['source_realm_id', 'target_dominion_id', 'type']);
-
-            $table->boolean('latest')->default(true);
-
-            $table->foreign('source_realm_id')->references('id')->on('realms');
-            $table->foreign('target_dominion_id')->references('id')->on('dominions');
-
             $table->index(['source_realm_id', 'target_dominion_id', 'type']);
             $table->index(['source_realm_id', 'target_dominion_id', 'latest']);
+            $table->boolean('latest')->default(true);
+
+            $table->dropUnique(['source_realm_id', 'target_dominion_id', 'type']);
         });
     }
 
@@ -36,16 +30,11 @@ class RemoveInfoOpsSourceRealmTargetDominionConstraint extends Migration
     public function down()
     {
         Schema::table('info_ops', function (Blueprint $table) {
-            $table->dropForeign(['source_realm_id']);
-            $table->dropForeign(['target_dominion_id']);
+            $table->unique(['source_realm_id', 'target_dominion_id', 'type']);
 
             $table->dropIndex(['source_realm_id', 'target_dominion_id', 'type']);
             $table->dropIndex(['source_realm_id', 'target_dominion_id', 'latest']);
             $table->dropColumn(['latest']);
-
-            $table->unique(['source_realm_id', 'target_dominion_id', 'type']);
-            $table->foreign('source_realm_id')->references('id')->on('realms');
-            $table->foreign('target_dominion_id')->references('id')->on('dominions');
         });
     }
 }

--- a/app/database/migrations/2019_06_24_192144_remove_info_ops_source_realm_target_dominion_constraint.php
+++ b/app/database/migrations/2019_06_24_192144_remove_info_ops_source_realm_target_dominion_constraint.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class RemoveInfoOpsSourceRealmTargetDominionConstraint extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('info_ops', function (Blueprint $table) {
+            $table->dropForeign(['source_realm_id']);
+            $table->dropForeign(['target_dominion_id']);
+            $table->dropUnique(['source_realm_id', 'target_dominion_id', 'type']);
+
+            $table->foreign('source_realm_id')->references('id')->on('realms');
+            $table->foreign('target_dominion_id')->references('id')->on('dominions');
+
+            $table->index(['type']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('info_ops', function (Blueprint $table) {
+            $table->dropIndex(['type']);
+            $table->unique(['source_realm_id', 'target_dominion_id', 'type']);
+        });
+    }
+}

--- a/app/database/migrations/2019_06_24_192144_remove_info_ops_source_realm_target_dominion_constraint.php
+++ b/app/database/migrations/2019_06_24_192144_remove_info_ops_source_realm_target_dominion_constraint.php
@@ -1,8 +1,8 @@
 <?php
 
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class RemoveInfoOpsSourceRealmTargetDominionConstraint extends Migration
 {

--- a/app/resources/views/pages/dominion/op-center/archive.blade.php
+++ b/app/resources/views/pages/dominion/op-center/archive.blade.php
@@ -1,0 +1,695 @@
+@extends('layouts.master')
+
+@section('page-header', 'Op Center')
+
+@section('content')
+    <div class="row">
+        <div class="col-sm-12 col-md-9">
+            @component('partials.dominion.op-center.box')
+                @slot('title', ('Archived Ops (' . $dominion->name . ')'))
+                @slot('titleIconClass', 'fa fa-book')
+
+                <p>This page contains the data that your realmies have gathered about dominion <b>{{ $dominion->name }}</b> from realm {{ $dominion->realm->name }} (#{{ $dominion->realm->number }}).</p>
+
+                <p>
+                    @if (!$infoOpArchive->count())
+                        No recent data available.
+                    @endif
+                </p>
+
+                @slot('boxFooter')
+                    <div class="pull-right">
+                        <a href="{{ route('dominion.op-center.show', $dominion) }}" class="btn btn-sm btn-primary">Back to Overview</a>
+                    </div>
+                @endslot
+            @endcomponent
+        </div>
+
+        <div class="col-sm-12 col-md-3">
+            <div class="box">
+                <div class="box-header with-border">
+                    <h3 class="box-title">Information</h3>
+                </div>
+                <div class="box-body">
+                    <p>Sections marked as <span class="label label-warning">stale</span> contain data from the previous hour (or earlier) and should be considered inaccurate. Recast your info ops before performing any offensive operations during this hour.</p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row">
+        @foreach ($infoOpArchive as $infoOp)
+            @if ($infoOp->type == 'clear_sight')
+                <div class="col-sm-12 col-md-9">
+                    @component('partials.dominion.op-center.box')
+                        @slot('title', ('Status Screen (' . $dominion->name . ')'))
+                        @slot('titleIconClass', 'fa fa-bar-chart')
+
+                        @php
+                            $race = OpenDominion\Models\Race::findOrFail($infoOp->data['race_id']);
+                        @endphp
+
+                        @slot('noPadding', true)
+
+                        <div class="row">
+                            <div class="col-xs-12 col-sm-4">
+                                <table class="table">
+                                    <colgroup>
+                                        <col width="50%">
+                                        <col width="50%">
+                                    </colgroup>
+                                    <thead>
+                                        <tr>
+                                            <th colspan="2">Overview</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr>
+                                            <td>Ruler:</td>
+                                            <td>{{ $infoOp->data['ruler_name'] }}</td>
+                                        </tr>
+                                        <tr>
+                                            <td>Race:</td>
+                                            <td>{{ $race->name }}</td>
+                                        </tr>
+                                        <tr>
+                                            <td>Land:</td>
+                                            <td>
+                                                {{ number_format($infoOp->data['land']) }}
+                                                <span class="{{ $rangeCalculator->getDominionRangeSpanClass($selectedDominion, $dominion) }}">
+                                                    ({{ number_format($rangeCalculator->getDominionRange($selectedDominion, $dominion), 1) }}%)
+                                                </span>
+                                            </td>
+                                        </tr>
+                                        <tr>
+                                            <td>Peasants:</td>
+                                            <td>{{ number_format($infoOp->data['peasants']) }}</td>
+                                        </tr>
+                                        <tr>
+                                            <td>Employment:</td>
+                                            <td>{{ number_format($infoOp->data['employment'], 2) }}%</td>
+                                        </tr>
+                                        <tr>
+                                            <td>Networth:</td>
+                                            <td>{{ number_format($infoOp->data['networth']) }}</td>
+                                        </tr>
+                                        <tr>
+                                            <td>Prestige:</td>
+                                            <td>{{ number_format($infoOp->data['prestige']) }}</td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                            <div class="col-xs-12 col-sm-4">
+                                <table class="table">
+                                    <colgroup>
+                                        <col width="50%">
+                                        <col width="50%">
+                                    </colgroup>
+                                    <thead>
+                                        <tr>
+                                            <th colspan="2">Resources</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr>
+                                            <td>Platinum:</td>
+                                            <td>{{ number_format($infoOp->data['resource_platinum']) }}</td>
+                                        </tr>
+                                        <tr>
+                                            <td>Food:</td>
+                                            <td>{{ number_format($infoOp->data['resource_food']) }}</td>
+                                        </tr>
+                                        <tr>
+                                            <td>Lumber:</td>
+                                            <td>{{ number_format($infoOp->data['resource_lumber']) }}</td>
+                                        </tr>
+                                        <tr>
+                                            <td>Mana:</td>
+                                            <td>{{ number_format($infoOp->data['resource_mana']) }}</td>
+                                        </tr>
+                                        <tr>
+                                            <td>Ore:</td>
+                                            <td>{{ number_format($infoOp->data['resource_ore']) }}</td>
+                                        </tr>
+                                        <tr>
+                                            <td>Gems:</td>
+                                            <td>{{ number_format($infoOp->data['resource_gems']) }}</td>
+                                        </tr>
+                                        <tr>
+                                            <td class="nyi">Research Points:</td>
+                                            <td class="nyi">{{ number_format($infoOp->data['resource_tech']) }}</td>
+                                        </tr>
+                                        <tr>
+                                            <td>Boats:</td>
+                                            <td>{{ number_format($infoOp->data['resource_boats']) }}</td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                            <div class="col-xs-12 col-sm-4">
+                                <table class="table">
+                                    <colgroup>
+                                        <col width="50%">
+                                        <col width="50%">
+                                    </colgroup>
+                                    <thead>
+                                        <tr>
+                                            <th colspan="2">Military</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr>
+                                            <td>Morale:</td>
+                                            <td>{{ number_format($infoOp->data['morale']) }}%</td>
+                                        </tr>
+                                        <tr>
+                                            <td>Draftees:</td>
+                                            <td>{{ number_format($infoOp->data['military_draftees']) }}</td>
+                                        </tr>
+                                        <tr>
+                                            <td>{{ $race->units->get(0)->name }}:</td>
+                                            <td>{{ number_format($infoOp->data['military_unit1']) }}</td>
+                                        </tr>
+                                        <tr>
+                                            <td>{{ $race->units->get(1)->name }}:</td>
+                                            <td>{{ number_format($infoOp->data['military_unit2']) }}</td>
+                                        </tr>
+                                        <tr>
+                                            <td>{{ $race->units->get(2)->name }}:</td>
+                                            <td>{{ number_format($infoOp->data['military_unit3']) }}</td>
+                                        </tr>
+                                        <tr>
+                                            <td>{{ $race->units->get(3)->name }}:</td>
+                                            <td>{{ number_format($infoOp->data['military_unit4']) }}</td>
+                                        </tr>
+                                        <tr>
+                                            <td>Spies:</td>
+                                            <td>???</td>
+                                        </tr>
+                                        <tr>
+                                            <td>Wizards:</td>
+                                            <td>???</td>
+                                        </tr>
+                                        <tr>
+                                            <td>ArchMages:</td>
+                                            <td>???</td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+
+                        @php
+                            $recentlyInvadedCount = (isset($infoOp->data['recently_invaded_count']) ? (int)$infoOp->data['recently_invaded_count'] : 0);
+                        @endphp
+
+                        @if ($recentlyInvadedCount > 0)
+                            <p class="text-center" style="margin-bottom: 0.5em;">
+                                @if ($recentlyInvadedCount >= 5)
+                                    This dominion has been invaded <strong><em>extremely heavily</em></strong> in recent times.
+                                @elseif ($recentlyInvadedCount >= 3)
+                                    This dominion has been invaded <strong>heavily</strong> in recent times.
+                                @else
+                                    This dominion has been invaded in recent times.
+                                @endif
+                            </p>
+                        @endif
+
+                        @slot('boxFooter')
+                            @if ($infoOp !== null)
+                                <em>Revealed {{ $infoOp->updated_at }} by {{ $infoOp->sourceDominion->name }}</em>
+                                @if ($infoOp->isStale())
+                                    <span class="label label-warning">Stale</span>
+                                @endif
+                            @endif
+                        @endslot
+                    @endcomponent
+                </div>
+            @endif
+
+            @if ($infoOp->type == 'revelation')
+                <div class="col-sm-12 col-md-6">
+                    @component('partials.dominion.op-center.box')
+                        @slot('title', 'Active Spells')
+                        @slot('titleIconClass', 'ra ra-fairy-wand')
+
+                        @slot('noPadding', true)
+
+                        <table class="table">
+                            <colgroup>
+                                <col width="150">
+                                <col>
+                                <col width="100">
+                                <col width="200s">
+                            </colgroup>
+                            <thead>
+                                <tr>
+                                    <th>Spell</th>
+                                    <th>Effect</th>
+                                    <th class="text-center">Duration</th>
+                                    <th class="text-center">Cast By</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach ($infoOp->data as $spell)
+                                    @php
+                                        $spellInfo = $spellHelper->getSpellInfo($spell['spell'], $dominion->race);
+                                        $castByDominion = OpenDominion\Models\Dominion::with('realm')->findOrFail($spell['cast_by_dominion_id']);
+                                    @endphp
+                                    <tr>
+                                        <td>{{ $spellInfo['name'] }}</td>
+                                        <td>{{ $spellInfo['description'] }}</td>
+                                        <td class="text-center">{{ $spell['duration'] }}</td>
+                                        <td class="text-center">
+                                            <a href="{{ route('dominion.realm', $castByDominion->realm->number) }}">{{ $castByDominion->name }} (#{{ $castByDominion->realm->number }})</a>
+                                        </td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+
+                        @slot('boxFooter')
+                            @if ($infoOp !== null)
+                                <em>Revealed {{ $infoOp->updated_at }} by {{ $infoOp->sourceDominion->name }}</em>
+                                @if ($infoOp->isStale())
+                                    <span class="label label-warning">Stale</span>
+                                @endif
+                            @endif
+                        @endslot
+                    @endcomponent
+                </div>
+            @endif
+
+            @if ($infoOp->type == 'castle_spy')
+                <div class="col-sm-12 col-md-6">
+                    @component('partials.dominion.op-center.box')
+                        @slot('title', 'Improvements')
+                        @slot('titleIconClass', 'fa fa-arrow-up')
+
+                        @slot('noPadding', true)
+
+                        <table class="table">
+                            <colgroup>
+                                <col width="150">
+                                <col>
+                                <col width="100">
+                            </colgroup>
+                            <thead>
+                                <tr>
+                                    <td>Part</td>
+                                    <td>Rating</td>
+                                    <td class="text-center">Invested</td>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach ($improvementHelper->getImprovementTypes() as $improvementType)
+                                    <tr>
+                                        <td>
+                                            {{ ucfirst($improvementType) }}
+                                            {!! $improvementHelper->getImprovementImplementedString($improvementType) !!}
+                                            <i class="fa fa-question-circle" data-toggle="tooltip" data-placement="top" title="{{ $improvementHelper->getImprovementHelpString($improvementType) }}"></i>
+                                        </td>
+                                        <td>
+                                            {{ sprintf(
+                                                $improvementHelper->getImprovementRatingString($improvementType),
+                                                number_format((array_get($infoOp->data, "{$improvementType}.rating") * 100), 2)
+                                            ) }}
+                                        </td>
+                                        <td class="text-center">{{ number_format(array_get($infoOp->data, "{$improvementType}.points")) }}</td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+
+                        @slot('boxFooter')
+                            @if ($infoOp !== null)
+                                <em>Revealed {{ $infoOp->updated_at }} by {{ $infoOp->sourceDominion->name }}</em>
+                                @if ($infoOp->isStale())
+                                    <span class="label label-warning">Stale</span>
+                                @endif
+                            @endif
+                        @endslot
+                    @endcomponent
+                </div>
+            @endif
+
+            @if ($infoOp->type == 'barracks_spy')
+                <div class="col-sm-12 col-md-6">
+                    @component('partials.dominion.op-center.box')
+                        @slot('title', 'Units in training and home')
+                        @slot('titleIconClass', 'ra ra-sword')
+
+                        @slot('noPadding', true)
+
+                        <table class="table">
+                            <colgroup>
+                                <col>
+                                @for ($i = 1; $i <= 12; $i++)
+                                    <col width="20">
+                                @endfor
+                                <col width="100">
+                            </colgroup>
+                            <thead>
+                                <tr>
+                                    <th>Unit</th>
+                                    @for ($i = 1; $i <= 12; $i++)
+                                        <th class="text-center">{{ $i }}</th>
+                                    @endfor
+                                    <th class="text-center">Home (Training)</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>Draftees</td>
+                                    <td colspan="12">&nbsp;</td>
+                                    <td class="text-center">
+                                        {{ number_format(array_get($infoOp->data, 'units.home.draftees', 0)) }}
+                                    </td>
+                                </tr>
+                                @foreach ($unitHelper->getUnitTypes() as $unitType)
+                                    <tr>
+                                        <td>{{ $unitHelper->getUnitName($unitType, $dominion->race) }}</td>
+                                        @for ($i = 1; $i <= 12; $i++)
+                                            @php
+                                                $amount = array_get($infoOp->data, "units.training.{$unitType}.{$i}", 0);
+                                            @endphp
+                                            <td class="text-center">
+                                                @if ($amount === 0)
+                                                    -
+                                                @else
+                                                    {{ number_format($amount) }}
+                                                @endif
+                                            </td>
+                                        @endfor
+                                        <td class="text-center">
+                                            @php
+                                                $unitsAtHome = (int)array_get($infoOp->data, "units.home.{$unitType}");
+                                            @endphp
+
+                                            @if (in_array($unitType, ['spies', 'wizards', 'archmages']))
+                                                ???
+                                            @elseif ($unitsAtHome !== 0)
+                                                ~{{ number_format($unitsAtHome) }}
+                                            @else
+                                                0
+                                            @endif
+
+                                            @if ($amountTraining = array_get($infoOp->data, "units.training.{$unitType}"))
+                                                ({{ number_format(array_sum($amountTraining)) }})
+                                            @endif
+                                        </td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+
+                        @slot('boxFooter')
+                            @if ($infoOp !== null)
+                                <em>Revealed {{ $infoOp->updated_at }} by {{ $infoOp->sourceDominion->name }}</em>
+                                @if ($infoOp->isStale())
+                                    <span class="label label-warning">Stale</span>
+                                @endif
+                            @endif
+                        @endslot
+                    @endcomponent
+                </div>
+                <div class="col-sm-12 col-md-6">
+                    @component('partials.dominion.op-center.box')
+                        @slot('title', 'Units returning from battle')
+                        @slot('titleIconClass', 'fa fa-clock-o')
+
+                        @slot('noPadding', true)
+
+                        <table class="table">
+                            <colgroup>
+                                <col>
+                                @for ($i = 1; $i <= 12; $i++)
+                                    <col width="20">
+                                @endfor
+                                <col width="100">
+                            </colgroup>
+                            <thead>
+                                <tr>
+                                    <th>Unit</th>
+                                    @for ($i = 1; $i <= 12; $i++)
+                                        <th class="text-center">{{ $i }}</th>
+                                    @endfor
+                                    <th class="text-center">Total</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (range(1, 4) as $slot)
+                                    @php
+                                        $unitType = ('unit' . $slot);
+                                    @endphp
+                                    <tr>
+                                        <td>{{ $unitHelper->getUnitName($unitType, $dominion->race) }}</td>
+                                        @for ($i = 1; $i <= 12; $i++)
+                                            @php
+                                                $amount = array_get($infoOp->data, "units.returning.{$unitType}.{$i}", 0);
+                                            @endphp
+                                            <td class="text-center">
+                                                @if ($amount === 0)
+                                                    -
+                                                @else
+                                                    {{ number_format($amount) }}
+                                                @endif
+                                            </td>
+                                        @endfor
+                                        <td class="text-center">
+                                            @if ($amountTraining = array_get($infoOp->data, "units.returning.{$unitType}"))
+                                                ~{{ number_format(array_sum($amountTraining)) }}
+                                            @else
+                                                0
+                                            @endif
+                                        </td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    @endcomponent
+                </div>
+            @endif
+
+            @if ($infoOp->type == 'survey_dominion')
+                <div class="col-sm-12 col-md-6">
+                    @component('partials.dominion.op-center.box')
+                        @slot('title', 'Constructed Buildings')
+                        @slot('titleIconClass', 'fa fa-home')
+
+                        @slot('noPadding', true)
+                        @slot('titleExtra')
+                            <span class="pull-right">Barren Land: {{ number_format(array_get($infoOp->data, 'barren_land')) }}</span>
+                        @endslot
+
+                        <table class="table">
+                            <colgroup>
+                                <col>
+                                <col width="100">
+                                <col width="100">
+                            </colgroup>
+                            <thead>
+                                <tr>
+                                    <th>Building Type</th>
+                                    <th class="text-center">Number</th>
+                                    <th class="text-center">% of land</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach ($buildingHelper->getBuildingTypes() as $buildingType)
+                                    @php
+                                        $amount = array_get($infoOp->data, "constructed.{$buildingType}");
+                                    @endphp
+                                    <tr>
+                                        <td>
+                                            {{ ucwords(str_replace('_', ' ', $buildingType)) }}
+                                            {!! $buildingHelper->getBuildingImplementedString($buildingType) !!}
+                                            <i class="fa fa-question-circle" data-toggle="tooltip" data-placement="top" title="{{ $buildingHelper->getBuildingHelpString($buildingType) }}"></i>
+                                        </td>
+                                        <td class="text-center">{{ number_format($amount) }}</td>
+                                        <td class="text-center">{{ number_format((($amount / $landCalculator->getTotalLand($dominion)) * 100), 2) }}%</td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+
+                        @slot('boxFooter')
+                            @if ($infoOp !== null)
+                                <em>Revealed {{ $infoOp->updated_at }} by {{ $infoOp->sourceDominion->name }}</em>
+                                @if ($infoOp->isStale())
+                                    <span class="label label-warning">Stale</span>
+                                @endif
+                            @endif
+                        @endslot
+                    @endcomponent
+                </div>
+
+                <div class="col-sm-12 col-md-6">
+                    @component('partials.dominion.op-center.box')
+                        @slot('title', 'Incoming building breakdown')
+                        @slot('titleIconClass', 'fa fa-clock-o')
+
+                        @slot('noPadding', true)
+
+                        <table class="table">
+                            <colgroup>
+                                <col>
+                                @for ($i = 1; $i <= 12; $i++)
+                                    <col width="20">
+                                @endfor
+                                <col width="100">
+                            </colgroup>
+                            <thead>
+                                <tr>
+                                    <th>Land Type</th>
+                                    @for ($i = 1; $i <= 12; $i++)
+                                        <th class="text-center">{{ $i }}</th>
+                                    @endfor
+                                    <th class="text-center">Total</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach ($buildingHelper->getBuildingTypes() as $buildingType)
+                                    <tr>
+                                        <td>{{ ucwords(str_replace('_', ' ', $buildingType)) }}</td>
+                                        @for ($i = 1; $i <= 12; $i++)
+                                            @php
+                                                $amount = array_get($infoOp->data, "constructing.{$buildingType}.{$i}", 0);
+                                            @endphp
+                                            <td class="text-center">
+                                                @if ($amount === 0)
+                                                    -
+                                                @else
+                                                    {{ number_format($amount) }}
+                                                @endif
+                                            </td>
+                                        @endfor
+                                        <td class="text-center">
+                                            @if ($amountConstructing = array_get($infoOp->data, "constructing.{$buildingType}"))
+                                                {{ number_format(array_sum($amountConstructing)) }}
+                                            @else
+                                                0
+                                            @endif
+                                        </td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    @endcomponent
+                </div>
+            @endif
+
+            @if ($infoOp->type == 'land_spy')
+                <div class="col-sm-12 col-md-6">
+                    @component('partials.dominion.op-center.box')
+                        @slot('title', 'Explored Land')
+                        @slot('titleIconClass', 'ra ra-honeycomb')
+
+                        @slot('noPadding', true)
+
+                        <table class="table">
+                            <colgroup>
+                                <col>
+                                <col width="100">
+                                <col width="100">
+                                <col width="100">
+                            </colgroup>
+                            <thead>
+                                <tr>
+                                    <th>Land Type</th>
+                                    <th class="text-center">Number</th>
+                                    <th class="text-center">% of total</th>
+                                    <th class="text-center">Barren</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach ($landHelper->getLandTypes() as $landType)
+                                    <tr>
+                                        <td>
+                                            {{ ucfirst($landType) }}
+                                            @if ($landType === $dominion->race->home_land_type)
+                                                <small class="text-muted"><i>(home)</i></small>
+                                            @endif
+                                        </td>
+                                        <td class="text-center">{{ number_format(array_get($infoOp->data, "explored.{$landType}.amount")) }}</td>
+                                        <td class="text-center">{{ number_format(array_get($infoOp->data, "explored.{$landType}.percentage"), 2) }}%</td>
+                                        <td class="text-center">{{ number_format(array_get($infoOp->data, "explored.{$landType}.barren")) }}</td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+
+                        @slot('boxFooter')
+                            @if ($infoOp !== null)
+                                <em>Revealed {{ $infoOp->updated_at }} by {{ $infoOp->sourceDominion->name }}</em>
+                                @if ($infoOp->isStale())
+                                    <span class="label label-warning">Stale</span>
+                                @endif
+                            @endif
+                        @endslot
+                    @endcomponent
+                </div>
+
+                <div class="col-sm-12 col-md-6">
+                    @component('partials.dominion.op-center.box')
+                        @slot('title', 'Incoming land breakdown')
+                        @slot('titleIconClass', 'fa fa-clock-o')
+
+                        @slot('noPadding', true)
+
+                        <table class="table">
+                            <colgroup>
+                                <col>
+                                @for ($i = 1; $i <= 12; $i++)
+                                    <col width="20">
+                                @endfor
+                                <col width="100">
+                            </colgroup>
+                            <thead>
+                                <tr>
+                                    <th>Land Type</th>
+                                    @for ($i = 1; $i <= 12; $i++)
+                                        <th class="text-center">{{ $i }}</th>
+                                    @endfor
+                                    <th class="text-center">Total</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach ($landHelper->getLandTypes() as $landType)
+                                    <tr>
+                                        <td>
+                                            {{ ucfirst($landType) }}
+                                            @if ($landType === $dominion->race->home_land_type)
+                                                <small class="text-muted"><i>(home)</i></small>
+                                            @endif
+                                        </td>
+                                        @for ($i = 1; $i <= 12; $i++)
+                                            @php
+                                                $amount = array_get($infoOp->data, "incoming.{$landType}.{$i}", 0);
+                                            @endphp
+                                            <td class="text-center">
+                                                @if ($amount === 0)
+                                                    -
+                                                @else
+                                                    {{ number_format($amount) }}
+                                                @endif
+                                            </td>
+                                        @endfor
+                                        <td class="text-center">
+                                            @if ($amountIncoming = array_get($infoOp->data, "incoming.{$landType}"))
+                                                {{ number_format(array_sum($amountIncoming)) }}
+                                            @else
+                                                0
+                                            @endif
+                                        </td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    @endcomponent
+                </div>
+            @endif
+        @endforeach
+    </div>
+@endsection

--- a/app/resources/views/pages/dominion/op-center/archive.blade.php
+++ b/app/resources/views/pages/dominion/op-center/archive.blade.php
@@ -49,6 +49,7 @@
                             $race = OpenDominion\Models\Race::findOrFail($infoOp->data['race_id']);
                         @endphp
 
+                        @slot('tableResponsive', false)
                         @slot('noPadding', true)
 
                         <div class="row">

--- a/app/resources/views/pages/dominion/op-center/archive.blade.php
+++ b/app/resources/views/pages/dominion/op-center/archive.blade.php
@@ -219,7 +219,7 @@
 
                         @slot('boxFooter')
                             @if ($infoOp !== null)
-                                <em>Revealed {{ $infoOp->updated_at }} by {{ $infoOp->sourceDominion->name }}</em>
+                                <em>Revealed {{ $infoOp->created_at }} by {{ $infoOp->sourceDominion->name }}</em>
                                 @if ($infoOp->isInvalid())
                                     <span class="label label-danger">Invalid</span>
                                 @elseif ($infoOp->isStale())
@@ -274,7 +274,7 @@
 
                         @slot('boxFooter')
                             @if ($infoOp !== null)
-                                <em>Revealed {{ $infoOp->updated_at }} by {{ $infoOp->sourceDominion->name }}</em>
+                                <em>Revealed {{ $infoOp->created_at }} by {{ $infoOp->sourceDominion->name }}</em>
                                 @if ($infoOp->isInvalid())
                                     <span class="label label-danger">Invalid</span>
                                 @elseif ($infoOp->isStale())
@@ -329,7 +329,7 @@
 
                         @slot('boxFooter')
                             @if ($infoOp !== null)
-                                <em>Revealed {{ $infoOp->updated_at }} by {{ $infoOp->sourceDominion->name }}</em>
+                                <em>Revealed {{ $infoOp->created_at }} by {{ $infoOp->sourceDominion->name }}</em>
                                 @if ($infoOp->isInvalid())
                                     <span class="label label-danger">Invalid</span>
                                 @elseif ($infoOp->isStale())
@@ -415,7 +415,7 @@
 
                                 @slot('boxFooter')
                                     @if ($infoOp !== null)
-                                        <em>Revealed {{ $infoOp->updated_at }} by {{ $infoOp->sourceDominion->name }}</em>
+                                        <em>Revealed {{ $infoOp->created_at }} by {{ $infoOp->sourceDominion->name }}</em>
                                         @if ($infoOp->isInvalid())
                                             <span class="label label-danger">Invalid</span>
                                         @elseif ($infoOp->isStale())
@@ -531,7 +531,7 @@
 
                                 @slot('boxFooter')
                                     @if ($infoOp !== null)
-                                        <em>Revealed {{ $infoOp->updated_at }} by {{ $infoOp->sourceDominion->name }}</em>
+                                        <em>Revealed {{ $infoOp->created_at }} by {{ $infoOp->sourceDominion->name }}</em>
                                         @if ($infoOp->isInvalid())
                                             <span class="label label-danger">Invalid</span>
                                         @elseif ($infoOp->isStale())
@@ -643,7 +643,7 @@
 
                                 @slot('boxFooter')
                                     @if ($infoOp !== null)
-                                        <em>Revealed {{ $infoOp->updated_at }} by {{ $infoOp->sourceDominion->name }}</em>
+                                        <em>Revealed {{ $infoOp->created_at }} by {{ $infoOp->sourceDominion->name }}</em>
                                         @if ($infoOp->isInvalid())
                                             <span class="label label-danger">Invalid</span>
                                         @elseif ($infoOp->isStale())

--- a/app/resources/views/pages/dominion/op-center/archive.blade.php
+++ b/app/resources/views/pages/dominion/op-center/archive.blade.php
@@ -692,4 +692,11 @@
             @endif
         @endforeach
     </div>
+    <div class="row">
+        <div class="col-sm-12">
+            <div class="text-center">
+                {{ $infoOpArchive->links() }}
+            </div>
+        </div>
+    </div>
 @endsection

--- a/app/resources/views/pages/dominion/op-center/archive.blade.php
+++ b/app/resources/views/pages/dominion/op-center/archive.blade.php
@@ -31,7 +31,7 @@
                     <h3 class="box-title">Information</h3>
                 </div>
                 <div class="box-body">
-                    <p>Sections marked as <span class="label label-warning">stale</span> contain data from the previous hour (or earlier) and should be considered inaccurate. Recast your info ops before performing any offensive operations during this hour.</p>
+                <p>Sections marked as <span class="label label-warning">stale</span> contain data from the previous hour (or earlier) and should be considered inaccurate. Sections marked as <span class="label label-danger">invalid</span> are more than 12 hours old. Recast your info ops before performing any offensive operations during this hour.</p>
                 </div>
             </div>
         </div>
@@ -220,7 +220,9 @@
                         @slot('boxFooter')
                             @if ($infoOp !== null)
                                 <em>Revealed {{ $infoOp->updated_at }} by {{ $infoOp->sourceDominion->name }}</em>
-                                @if ($infoOp->isStale())
+                                @if ($infoOp->isInvalid())
+                                    <span class="label label-danger">Invalid</span>
+                                @elseif ($infoOp->isStale())
                                     <span class="label label-warning">Stale</span>
                                 @endif
                             @endif
@@ -273,7 +275,9 @@
                         @slot('boxFooter')
                             @if ($infoOp !== null)
                                 <em>Revealed {{ $infoOp->updated_at }} by {{ $infoOp->sourceDominion->name }}</em>
-                                @if ($infoOp->isStale())
+                                @if ($infoOp->isInvalid())
+                                    <span class="label label-danger">Invalid</span>
+                                @elseif ($infoOp->isStale())
                                     <span class="label label-warning">Stale</span>
                                 @endif
                             @endif
@@ -326,7 +330,9 @@
                         @slot('boxFooter')
                             @if ($infoOp !== null)
                                 <em>Revealed {{ $infoOp->updated_at }} by {{ $infoOp->sourceDominion->name }}</em>
-                                @if ($infoOp->isStale())
+                                @if ($infoOp->isInvalid())
+                                    <span class="label label-danger">Invalid</span>
+                                @elseif ($infoOp->isStale())
                                     <span class="label label-warning">Stale</span>
                                 @endif
                             @endif
@@ -410,7 +416,9 @@
                                 @slot('boxFooter')
                                     @if ($infoOp !== null)
                                         <em>Revealed {{ $infoOp->updated_at }} by {{ $infoOp->sourceDominion->name }}</em>
-                                        @if ($infoOp->isStale())
+                                        @if ($infoOp->isInvalid())
+                                            <span class="label label-danger">Invalid</span>
+                                        @elseif ($infoOp->isStale())
                                             <span class="label label-warning">Stale</span>
                                         @endif
                                     @endif
@@ -524,7 +532,9 @@
                                 @slot('boxFooter')
                                     @if ($infoOp !== null)
                                         <em>Revealed {{ $infoOp->updated_at }} by {{ $infoOp->sourceDominion->name }}</em>
-                                        @if ($infoOp->isStale())
+                                        @if ($infoOp->isInvalid())
+                                            <span class="label label-danger">Invalid</span>
+                                        @elseif ($infoOp->isStale())
                                             <span class="label label-warning">Stale</span>
                                         @endif
                                     @endif
@@ -634,7 +644,9 @@
                                 @slot('boxFooter')
                                     @if ($infoOp !== null)
                                         <em>Revealed {{ $infoOp->updated_at }} by {{ $infoOp->sourceDominion->name }}</em>
-                                        @if ($infoOp->isStale())
+                                        @if ($infoOp->isInvalid())
+                                            <span class="label label-danger">Invalid</span>
+                                        @elseif ($infoOp->isStale())
                                             <span class="label label-warning">Stale</span>
                                         @endif
                                     @endif

--- a/app/resources/views/pages/dominion/op-center/archive.blade.php
+++ b/app/resources/views/pages/dominion/op-center/archive.blade.php
@@ -335,359 +335,371 @@
             @endif
 
             @if ($infoOp->type == 'barracks_spy')
-                <div class="col-sm-12 col-md-6">
-                    @component('partials.dominion.op-center.box')
-                        @slot('title', 'Units in training and home')
-                        @slot('titleIconClass', 'ra ra-sword')
+                <div class="col-sm-12">
+                    <div class="row">
+                        <div class="col-sm-12 col-md-6">
+                            @component('partials.dominion.op-center.box')
+                                @slot('title', 'Units in training and home')
+                                @slot('titleIconClass', 'ra ra-sword')
 
-                        @slot('noPadding', true)
+                                @slot('noPadding', true)
 
-                        <table class="table">
-                            <colgroup>
-                                <col>
-                                @for ($i = 1; $i <= 12; $i++)
-                                    <col width="20">
-                                @endfor
-                                <col width="100">
-                            </colgroup>
-                            <thead>
-                                <tr>
-                                    <th>Unit</th>
-                                    @for ($i = 1; $i <= 12; $i++)
-                                        <th class="text-center">{{ $i }}</th>
-                                    @endfor
-                                    <th class="text-center">Home (Training)</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                <tr>
-                                    <td>Draftees</td>
-                                    <td colspan="12">&nbsp;</td>
-                                    <td class="text-center">
-                                        {{ number_format(array_get($infoOp->data, 'units.home.draftees', 0)) }}
-                                    </td>
-                                </tr>
-                                @foreach ($unitHelper->getUnitTypes() as $unitType)
-                                    <tr>
-                                        <td>{{ $unitHelper->getUnitName($unitType, $dominion->race) }}</td>
+                                <table class="table">
+                                    <colgroup>
+                                        <col>
                                         @for ($i = 1; $i <= 12; $i++)
-                                            @php
-                                                $amount = array_get($infoOp->data, "units.training.{$unitType}.{$i}", 0);
-                                            @endphp
-                                            <td class="text-center">
-                                                @if ($amount === 0)
-                                                    -
-                                                @else
-                                                    {{ number_format($amount) }}
-                                                @endif
-                                            </td>
+                                            <col width="20">
                                         @endfor
-                                        <td class="text-center">
-                                            @php
-                                                $unitsAtHome = (int)array_get($infoOp->data, "units.home.{$unitType}");
-                                            @endphp
+                                        <col width="100">
+                                    </colgroup>
+                                    <thead>
+                                        <tr>
+                                            <th>Unit</th>
+                                            @for ($i = 1; $i <= 12; $i++)
+                                                <th class="text-center">{{ $i }}</th>
+                                            @endfor
+                                            <th class="text-center">Home (Training)</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr>
+                                            <td>Draftees</td>
+                                            <td colspan="12">&nbsp;</td>
+                                            <td class="text-center">
+                                                {{ number_format(array_get($infoOp->data, 'units.home.draftees', 0)) }}
+                                            </td>
+                                        </tr>
+                                        @foreach ($unitHelper->getUnitTypes() as $unitType)
+                                            <tr>
+                                                <td>{{ $unitHelper->getUnitName($unitType, $dominion->race) }}</td>
+                                                @for ($i = 1; $i <= 12; $i++)
+                                                    @php
+                                                        $amount = array_get($infoOp->data, "units.training.{$unitType}.{$i}", 0);
+                                                    @endphp
+                                                    <td class="text-center">
+                                                        @if ($amount === 0)
+                                                            -
+                                                        @else
+                                                            {{ number_format($amount) }}
+                                                        @endif
+                                                    </td>
+                                                @endfor
+                                                <td class="text-center">
+                                                    @php
+                                                        $unitsAtHome = (int)array_get($infoOp->data, "units.home.{$unitType}");
+                                                    @endphp
 
-                                            @if (in_array($unitType, ['spies', 'wizards', 'archmages']))
-                                                ???
-                                            @elseif ($unitsAtHome !== 0)
-                                                ~{{ number_format($unitsAtHome) }}
-                                            @else
-                                                0
-                                            @endif
+                                                    @if (in_array($unitType, ['spies', 'wizards', 'archmages']))
+                                                        ???
+                                                    @elseif ($unitsAtHome !== 0)
+                                                        ~{{ number_format($unitsAtHome) }}
+                                                    @else
+                                                        0
+                                                    @endif
 
-                                            @if ($amountTraining = array_get($infoOp->data, "units.training.{$unitType}"))
-                                                ({{ number_format(array_sum($amountTraining)) }})
-                                            @endif
-                                        </td>
-                                    </tr>
-                                @endforeach
-                            </tbody>
-                        </table>
+                                                    @if ($amountTraining = array_get($infoOp->data, "units.training.{$unitType}"))
+                                                        ({{ number_format(array_sum($amountTraining)) }})
+                                                    @endif
+                                                </td>
+                                            </tr>
+                                        @endforeach
+                                    </tbody>
+                                </table>
 
-                        @slot('boxFooter')
-                            @if ($infoOp !== null)
-                                <em>Revealed {{ $infoOp->updated_at }} by {{ $infoOp->sourceDominion->name }}</em>
-                                @if ($infoOp->isStale())
-                                    <span class="label label-warning">Stale</span>
-                                @endif
-                            @endif
-                        @endslot
-                    @endcomponent
-                </div>
-                <div class="col-sm-12 col-md-6">
-                    @component('partials.dominion.op-center.box')
-                        @slot('title', 'Units returning from battle')
-                        @slot('titleIconClass', 'fa fa-clock-o')
+                                @slot('boxFooter')
+                                    @if ($infoOp !== null)
+                                        <em>Revealed {{ $infoOp->updated_at }} by {{ $infoOp->sourceDominion->name }}</em>
+                                        @if ($infoOp->isStale())
+                                            <span class="label label-warning">Stale</span>
+                                        @endif
+                                    @endif
+                                @endslot
+                            @endcomponent
+                        </div>
+                        <div class="col-sm-12 col-md-6">
+                            @component('partials.dominion.op-center.box')
+                                @slot('title', 'Units returning from battle')
+                                @slot('titleIconClass', 'fa fa-clock-o')
 
-                        @slot('noPadding', true)
+                                @slot('noPadding', true)
 
-                        <table class="table">
-                            <colgroup>
-                                <col>
-                                @for ($i = 1; $i <= 12; $i++)
-                                    <col width="20">
-                                @endfor
-                                <col width="100">
-                            </colgroup>
-                            <thead>
-                                <tr>
-                                    <th>Unit</th>
-                                    @for ($i = 1; $i <= 12; $i++)
-                                        <th class="text-center">{{ $i }}</th>
-                                    @endfor
-                                    <th class="text-center">Total</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                @foreach (range(1, 4) as $slot)
-                                    @php
-                                        $unitType = ('unit' . $slot);
-                                    @endphp
-                                    <tr>
-                                        <td>{{ $unitHelper->getUnitName($unitType, $dominion->race) }}</td>
+                                <table class="table">
+                                    <colgroup>
+                                        <col>
                                         @for ($i = 1; $i <= 12; $i++)
-                                            @php
-                                                $amount = array_get($infoOp->data, "units.returning.{$unitType}.{$i}", 0);
-                                            @endphp
-                                            <td class="text-center">
-                                                @if ($amount === 0)
-                                                    -
-                                                @else
-                                                    {{ number_format($amount) }}
-                                                @endif
-                                            </td>
+                                            <col width="20">
                                         @endfor
-                                        <td class="text-center">
-                                            @if ($amountTraining = array_get($infoOp->data, "units.returning.{$unitType}"))
-                                                ~{{ number_format(array_sum($amountTraining)) }}
-                                            @else
-                                                0
-                                            @endif
-                                        </td>
-                                    </tr>
-                                @endforeach
-                            </tbody>
-                        </table>
-                    @endcomponent
+                                        <col width="100">
+                                    </colgroup>
+                                    <thead>
+                                        <tr>
+                                            <th>Unit</th>
+                                            @for ($i = 1; $i <= 12; $i++)
+                                                <th class="text-center">{{ $i }}</th>
+                                            @endfor
+                                            <th class="text-center">Total</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        @foreach (range(1, 4) as $slot)
+                                            @php
+                                                $unitType = ('unit' . $slot);
+                                            @endphp
+                                            <tr>
+                                                <td>{{ $unitHelper->getUnitName($unitType, $dominion->race) }}</td>
+                                                @for ($i = 1; $i <= 12; $i++)
+                                                    @php
+                                                        $amount = array_get($infoOp->data, "units.returning.{$unitType}.{$i}", 0);
+                                                    @endphp
+                                                    <td class="text-center">
+                                                        @if ($amount === 0)
+                                                            -
+                                                        @else
+                                                            {{ number_format($amount) }}
+                                                        @endif
+                                                    </td>
+                                                @endfor
+                                                <td class="text-center">
+                                                    @if ($amountTraining = array_get($infoOp->data, "units.returning.{$unitType}"))
+                                                        ~{{ number_format(array_sum($amountTraining)) }}
+                                                    @else
+                                                        0
+                                                    @endif
+                                                </td>
+                                            </tr>
+                                        @endforeach
+                                    </tbody>
+                                </table>
+                            @endcomponent
+                        </div>
+                    </div>
                 </div>
             @endif
 
             @if ($infoOp->type == 'survey_dominion')
-                <div class="col-sm-12 col-md-6">
-                    @component('partials.dominion.op-center.box')
-                        @slot('title', 'Constructed Buildings')
-                        @slot('titleIconClass', 'fa fa-home')
+                <div class="col-sm-12">
+                    <div class="row">
+                        <div class="col-sm-12 col-md-6">
+                            @component('partials.dominion.op-center.box')
+                                @slot('title', 'Constructed Buildings')
+                                @slot('titleIconClass', 'fa fa-home')
 
-                        @slot('noPadding', true)
-                        @slot('titleExtra')
-                            <span class="pull-right">Barren Land: {{ number_format(array_get($infoOp->data, 'barren_land')) }}</span>
-                        @endslot
+                                @slot('noPadding', true)
+                                @slot('titleExtra')
+                                    <span class="pull-right">Barren Land: {{ number_format(array_get($infoOp->data, 'barren_land')) }}</span>
+                                @endslot
 
-                        <table class="table">
-                            <colgroup>
-                                <col>
-                                <col width="100">
-                                <col width="100">
-                            </colgroup>
-                            <thead>
-                                <tr>
-                                    <th>Building Type</th>
-                                    <th class="text-center">Number</th>
-                                    <th class="text-center">% of land</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                @foreach ($buildingHelper->getBuildingTypes() as $buildingType)
-                                    @php
-                                        $amount = array_get($infoOp->data, "constructed.{$buildingType}");
-                                    @endphp
-                                    <tr>
-                                        <td>
-                                            {{ ucwords(str_replace('_', ' ', $buildingType)) }}
-                                            {!! $buildingHelper->getBuildingImplementedString($buildingType) !!}
-                                            <i class="fa fa-question-circle" data-toggle="tooltip" data-placement="top" title="{{ $buildingHelper->getBuildingHelpString($buildingType) }}"></i>
-                                        </td>
-                                        <td class="text-center">{{ number_format($amount) }}</td>
-                                        <td class="text-center">{{ number_format((($amount / $landCalculator->getTotalLand($dominion)) * 100), 2) }}%</td>
-                                    </tr>
-                                @endforeach
-                            </tbody>
-                        </table>
-
-                        @slot('boxFooter')
-                            @if ($infoOp !== null)
-                                <em>Revealed {{ $infoOp->updated_at }} by {{ $infoOp->sourceDominion->name }}</em>
-                                @if ($infoOp->isStale())
-                                    <span class="label label-warning">Stale</span>
-                                @endif
-                            @endif
-                        @endslot
-                    @endcomponent
-                </div>
-
-                <div class="col-sm-12 col-md-6">
-                    @component('partials.dominion.op-center.box')
-                        @slot('title', 'Incoming building breakdown')
-                        @slot('titleIconClass', 'fa fa-clock-o')
-
-                        @slot('noPadding', true)
-
-                        <table class="table">
-                            <colgroup>
-                                <col>
-                                @for ($i = 1; $i <= 12; $i++)
-                                    <col width="20">
-                                @endfor
-                                <col width="100">
-                            </colgroup>
-                            <thead>
-                                <tr>
-                                    <th>Land Type</th>
-                                    @for ($i = 1; $i <= 12; $i++)
-                                        <th class="text-center">{{ $i }}</th>
-                                    @endfor
-                                    <th class="text-center">Total</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                @foreach ($buildingHelper->getBuildingTypes() as $buildingType)
-                                    <tr>
-                                        <td>{{ ucwords(str_replace('_', ' ', $buildingType)) }}</td>
-                                        @for ($i = 1; $i <= 12; $i++)
+                                <table class="table">
+                                    <colgroup>
+                                        <col>
+                                        <col width="100">
+                                        <col width="100">
+                                    </colgroup>
+                                    <thead>
+                                        <tr>
+                                            <th>Building Type</th>
+                                            <th class="text-center">Number</th>
+                                            <th class="text-center">% of land</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        @foreach ($buildingHelper->getBuildingTypes() as $buildingType)
                                             @php
-                                                $amount = array_get($infoOp->data, "constructing.{$buildingType}.{$i}", 0);
+                                                $amount = array_get($infoOp->data, "constructed.{$buildingType}");
                                             @endphp
-                                            <td class="text-center">
-                                                @if ($amount === 0)
-                                                    -
-                                                @else
-                                                    {{ number_format($amount) }}
-                                                @endif
-                                            </td>
+                                            <tr>
+                                                <td>
+                                                    {{ ucwords(str_replace('_', ' ', $buildingType)) }}
+                                                    {!! $buildingHelper->getBuildingImplementedString($buildingType) !!}
+                                                    <i class="fa fa-question-circle" data-toggle="tooltip" data-placement="top" title="{{ $buildingHelper->getBuildingHelpString($buildingType) }}"></i>
+                                                </td>
+                                                <td class="text-center">{{ number_format($amount) }}</td>
+                                                <td class="text-center">{{ number_format((($amount / $landCalculator->getTotalLand($dominion)) * 100), 2) }}%</td>
+                                            </tr>
+                                        @endforeach
+                                    </tbody>
+                                </table>
+
+                                @slot('boxFooter')
+                                    @if ($infoOp !== null)
+                                        <em>Revealed {{ $infoOp->updated_at }} by {{ $infoOp->sourceDominion->name }}</em>
+                                        @if ($infoOp->isStale())
+                                            <span class="label label-warning">Stale</span>
+                                        @endif
+                                    @endif
+                                @endslot
+                            @endcomponent
+                        </div>
+
+                        <div class="col-sm-12 col-md-6">
+                            @component('partials.dominion.op-center.box')
+                                @slot('title', 'Incoming building breakdown')
+                                @slot('titleIconClass', 'fa fa-clock-o')
+
+                                @slot('noPadding', true)
+
+                                <table class="table">
+                                    <colgroup>
+                                        <col>
+                                        @for ($i = 1; $i <= 12; $i++)
+                                            <col width="20">
                                         @endfor
-                                        <td class="text-center">
-                                            @if ($amountConstructing = array_get($infoOp->data, "constructing.{$buildingType}"))
-                                                {{ number_format(array_sum($amountConstructing)) }}
-                                            @else
-                                                0
-                                            @endif
-                                        </td>
-                                    </tr>
-                                @endforeach
-                            </tbody>
-                        </table>
-                    @endcomponent
+                                        <col width="100">
+                                    </colgroup>
+                                    <thead>
+                                        <tr>
+                                            <th>Land Type</th>
+                                            @for ($i = 1; $i <= 12; $i++)
+                                                <th class="text-center">{{ $i }}</th>
+                                            @endfor
+                                            <th class="text-center">Total</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        @foreach ($buildingHelper->getBuildingTypes() as $buildingType)
+                                            <tr>
+                                                <td>{{ ucwords(str_replace('_', ' ', $buildingType)) }}</td>
+                                                @for ($i = 1; $i <= 12; $i++)
+                                                    @php
+                                                        $amount = array_get($infoOp->data, "constructing.{$buildingType}.{$i}", 0);
+                                                    @endphp
+                                                    <td class="text-center">
+                                                        @if ($amount === 0)
+                                                            -
+                                                        @else
+                                                            {{ number_format($amount) }}
+                                                        @endif
+                                                    </td>
+                                                @endfor
+                                                <td class="text-center">
+                                                    @if ($amountConstructing = array_get($infoOp->data, "constructing.{$buildingType}"))
+                                                        {{ number_format(array_sum($amountConstructing)) }}
+                                                    @else
+                                                        0
+                                                    @endif
+                                                </td>
+                                            </tr>
+                                        @endforeach
+                                    </tbody>
+                                </table>
+                            @endcomponent
+                        </div>
+                    </div>
                 </div>
             @endif
 
             @if ($infoOp->type == 'land_spy')
-                <div class="col-sm-12 col-md-6">
-                    @component('partials.dominion.op-center.box')
-                        @slot('title', 'Explored Land')
-                        @slot('titleIconClass', 'ra ra-honeycomb')
+                <div class="col-sm-12">
+                    <div class="row">
+                        <div class="col-sm-12 col-md-6">
+                            @component('partials.dominion.op-center.box')
+                                @slot('title', 'Explored Land')
+                                @slot('titleIconClass', 'ra ra-honeycomb')
 
-                        @slot('noPadding', true)
+                                @slot('noPadding', true)
 
-                        <table class="table">
-                            <colgroup>
-                                <col>
-                                <col width="100">
-                                <col width="100">
-                                <col width="100">
-                            </colgroup>
-                            <thead>
-                                <tr>
-                                    <th>Land Type</th>
-                                    <th class="text-center">Number</th>
-                                    <th class="text-center">% of total</th>
-                                    <th class="text-center">Barren</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                @foreach ($landHelper->getLandTypes() as $landType)
-                                    <tr>
-                                        <td>
-                                            {{ ucfirst($landType) }}
-                                            @if ($landType === $dominion->race->home_land_type)
-                                                <small class="text-muted"><i>(home)</i></small>
-                                            @endif
-                                        </td>
-                                        <td class="text-center">{{ number_format(array_get($infoOp->data, "explored.{$landType}.amount")) }}</td>
-                                        <td class="text-center">{{ number_format(array_get($infoOp->data, "explored.{$landType}.percentage"), 2) }}%</td>
-                                        <td class="text-center">{{ number_format(array_get($infoOp->data, "explored.{$landType}.barren")) }}</td>
-                                    </tr>
-                                @endforeach
-                            </tbody>
-                        </table>
+                                <table class="table">
+                                    <colgroup>
+                                        <col>
+                                        <col width="100">
+                                        <col width="100">
+                                        <col width="100">
+                                    </colgroup>
+                                    <thead>
+                                        <tr>
+                                            <th>Land Type</th>
+                                            <th class="text-center">Number</th>
+                                            <th class="text-center">% of total</th>
+                                            <th class="text-center">Barren</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        @foreach ($landHelper->getLandTypes() as $landType)
+                                            <tr>
+                                                <td>
+                                                    {{ ucfirst($landType) }}
+                                                    @if ($landType === $dominion->race->home_land_type)
+                                                        <small class="text-muted"><i>(home)</i></small>
+                                                    @endif
+                                                </td>
+                                                <td class="text-center">{{ number_format(array_get($infoOp->data, "explored.{$landType}.amount")) }}</td>
+                                                <td class="text-center">{{ number_format(array_get($infoOp->data, "explored.{$landType}.percentage"), 2) }}%</td>
+                                                <td class="text-center">{{ number_format(array_get($infoOp->data, "explored.{$landType}.barren")) }}</td>
+                                            </tr>
+                                        @endforeach
+                                    </tbody>
+                                </table>
 
-                        @slot('boxFooter')
-                            @if ($infoOp !== null)
-                                <em>Revealed {{ $infoOp->updated_at }} by {{ $infoOp->sourceDominion->name }}</em>
-                                @if ($infoOp->isStale())
-                                    <span class="label label-warning">Stale</span>
-                                @endif
-                            @endif
-                        @endslot
-                    @endcomponent
-                </div>
+                                @slot('boxFooter')
+                                    @if ($infoOp !== null)
+                                        <em>Revealed {{ $infoOp->updated_at }} by {{ $infoOp->sourceDominion->name }}</em>
+                                        @if ($infoOp->isStale())
+                                            <span class="label label-warning">Stale</span>
+                                        @endif
+                                    @endif
+                                @endslot
+                            @endcomponent
+                        </div>
 
-                <div class="col-sm-12 col-md-6">
-                    @component('partials.dominion.op-center.box')
-                        @slot('title', 'Incoming land breakdown')
-                        @slot('titleIconClass', 'fa fa-clock-o')
+                        <div class="col-sm-12 col-md-6">
+                            @component('partials.dominion.op-center.box')
+                                @slot('title', 'Incoming land breakdown')
+                                @slot('titleIconClass', 'fa fa-clock-o')
 
-                        @slot('noPadding', true)
+                                @slot('noPadding', true)
 
-                        <table class="table">
-                            <colgroup>
-                                <col>
-                                @for ($i = 1; $i <= 12; $i++)
-                                    <col width="20">
-                                @endfor
-                                <col width="100">
-                            </colgroup>
-                            <thead>
-                                <tr>
-                                    <th>Land Type</th>
-                                    @for ($i = 1; $i <= 12; $i++)
-                                        <th class="text-center">{{ $i }}</th>
-                                    @endfor
-                                    <th class="text-center">Total</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                @foreach ($landHelper->getLandTypes() as $landType)
-                                    <tr>
-                                        <td>
-                                            {{ ucfirst($landType) }}
-                                            @if ($landType === $dominion->race->home_land_type)
-                                                <small class="text-muted"><i>(home)</i></small>
-                                            @endif
-                                        </td>
+                                <table class="table">
+                                    <colgroup>
+                                        <col>
                                         @for ($i = 1; $i <= 12; $i++)
-                                            @php
-                                                $amount = array_get($infoOp->data, "incoming.{$landType}.{$i}", 0);
-                                            @endphp
-                                            <td class="text-center">
-                                                @if ($amount === 0)
-                                                    -
-                                                @else
-                                                    {{ number_format($amount) }}
-                                                @endif
-                                            </td>
+                                            <col width="20">
                                         @endfor
-                                        <td class="text-center">
-                                            @if ($amountIncoming = array_get($infoOp->data, "incoming.{$landType}"))
-                                                {{ number_format(array_sum($amountIncoming)) }}
-                                            @else
-                                                0
-                                            @endif
-                                        </td>
-                                    </tr>
-                                @endforeach
-                            </tbody>
-                        </table>
-                    @endcomponent
+                                        <col width="100">
+                                    </colgroup>
+                                    <thead>
+                                        <tr>
+                                            <th>Land Type</th>
+                                            @for ($i = 1; $i <= 12; $i++)
+                                                <th class="text-center">{{ $i }}</th>
+                                            @endfor
+                                            <th class="text-center">Total</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        @foreach ($landHelper->getLandTypes() as $landType)
+                                            <tr>
+                                                <td>
+                                                    {{ ucfirst($landType) }}
+                                                    @if ($landType === $dominion->race->home_land_type)
+                                                        <small class="text-muted"><i>(home)</i></small>
+                                                    @endif
+                                                </td>
+                                                @for ($i = 1; $i <= 12; $i++)
+                                                    @php
+                                                        $amount = array_get($infoOp->data, "incoming.{$landType}.{$i}", 0);
+                                                    @endphp
+                                                    <td class="text-center">
+                                                        @if ($amount === 0)
+                                                            -
+                                                        @else
+                                                            {{ number_format($amount) }}
+                                                        @endif
+                                                    </td>
+                                                @endfor
+                                                <td class="text-center">
+                                                    @if ($amountIncoming = array_get($infoOp->data, "incoming.{$landType}"))
+                                                        {{ number_format(array_sum($amountIncoming)) }}
+                                                    @else
+                                                        0
+                                                    @endif
+                                                </td>
+                                            </tr>
+                                        @endforeach
+                                    </tbody>
+                                </table>
+                            @endcomponent
+                        </div>
+                    </div>
                 </div>
             @endif
         @endforeach

--- a/app/resources/views/pages/dominion/op-center/index.blade.php
+++ b/app/resources/views/pages/dominion/op-center/index.blade.php
@@ -16,7 +16,10 @@
                             <col>
                             <col>
                             <col width="100">
+                            {{--
                             <col width="100">
+                            <col width="100">
+                            --}}
                             <col width="100">
                             <col width="100">
                             <col width="200">
@@ -26,8 +29,11 @@
                             <tr>
                                 <th>Dominion</th>
                                 <th>Realm</th>
+                                <th class="text-center">Race</th>
+                                {{--
                                 <th class="text-center">OP</th>
                                 <th class="text-center">DP</th>
+                                --}}
                                 <th class="text-center">Land</th>
                                 <th class="text-center">Networth</th>
                                 <th class="text-center">Last Op</th>
@@ -53,12 +59,17 @@
                                         <a href="{{ route('dominion.realm', $dominion->realm->number) }}">{{ $dominion->realm->name }} (#{{ $dominion->realm->number }})</a>
                                         {{-- todo: highlight clicked dominion in realm page? --}}
                                     </td>
+                                    <td class="text-center" data-search="" data-order="{{ $dominion->race->name }}">
+                                        {{ $dominion->race->name }}
+                                    </td>
+                                    {{--
                                     <td class="text-center" data-search="" data-order="{{ $infoOpService->getOffensivePower($selectedDominion->realm, $dominion) }}">
                                         {{ $infoOpService->getOffensivePowerString($selectedDominion->realm, $dominion) }}
                                     </td>
                                     <td class="text-center" data-search="" data-order="{{ $infoOpService->getDefensivePower($selectedDominion->realm, $dominion) }}">
                                         {{ $infoOpService->getDefensivePowerString($selectedDominion->realm, $dominion) }}
                                     </td>
+                                    --}}
                                     <td class="text-center" data-search="" data-order="{{ $infoOpService->getLand($selectedDominion->realm, $dominion) }}">
                                         {{ $infoOpService->getLandString($selectedDominion->realm, $dominion) }}
                                         <br>

--- a/app/resources/views/pages/dominion/op-center/index.blade.php
+++ b/app/resources/views/pages/dominion/op-center/index.blade.php
@@ -45,13 +45,12 @@
                                 @php
                                     $lastInfoOp = $infoOpService->getLastInfoOp($selectedDominion->realm, $dominion);
                                 @endphp
-                                @if ($lastInfoOp == null || $lastInfoOp->isInvalid())
-                                    @continue
-                                @endif
                                 <tr>
                                     <td>
                                         <a href="{{ route('dominion.op-center.show', $dominion) }}">{{ $dominion->name }}</a>
-                                        @if ($lastInfoOp->isStale())
+                                        @if ($lastInfoOp->isInvalid())
+                                            <span class="label label-danger">Invalid</span>
+                                        @elseif ($lastInfoOp->isStale())
                                             <span class="label label-warning">Stale</span>
                                         @endif
                                     </td>
@@ -128,9 +127,6 @@
                                 @php
                                     $lastInfoOp = $infoOpService->getLastClairvoyance($selectedDominion->realm, $realm);
                                 @endphp
-                                @if ($lastInfoOp == null || $lastInfoOp->isInvalid())
-                                    @continue
-                                @endif
                                 <tr>
                                     <td data-order="{{ $realm->number }}">
                                         <a href="{{ route('dominion.op-center.clairvoyance', $realm->id) }}">{{ $realm->name }} (#{{ $realm->number }})</a>

--- a/app/resources/views/pages/dominion/op-center/index.blade.php
+++ b/app/resources/views/pages/dominion/op-center/index.blade.php
@@ -22,8 +22,8 @@
                             --}}
                             <col width="100">
                             <col width="100">
-                            <col width="200">
-                            <col width="50">
+                            <col width="160">
+                            <col width="130">
                         </colgroup>
                         <thead>
                             <tr>
@@ -37,11 +37,12 @@
                                 <th class="text-center">Land</th>
                                 <th class="text-center">Networth</th>
                                 <th class="text-center">Last Op</th>
-                                <th class="text-center">Ops</th>
+                                <th class="text-center">Recent Ops</th>
                             </tr>
                         </thead>
                         <tbody>
-                            @foreach ($latestInfoOps as $lastInfoOp)
+                            @foreach ($latestInfoOps as $targetDominionOps)
+                                @php $lastInfoOp = $targetDominionOps->first(); @endphp
                                 <tr>
                                     <td>
                                         <a href="{{ route('dominion.op-center.show', $lastInfoOp->targetDominion) }}">{{ $lastInfoOp->targetDominion->name }}</a>
@@ -77,7 +78,7 @@
                                         {{ $infoOpService->getNetworthString($selectedDominion->realm, $lastInfoOp->targetDominion) }}
                                     </td>
                                     <td class="text-center" data-search="" data-order="{{ $lastInfoOp->created_at->getTimestamp() }}">
-                                        {{ $infoOpService->getLastInfoOpName($selectedDominion->realm, $lastInfoOp->targetDominion) }}
+                                        {{ $infoOpService->getInfoOpName($lastInfoOp) }}
                                         by
                                         @if ($lastInfoOp->sourceDominion->id === $selectedDominion->id)
                                             <strong>

--- a/app/resources/views/pages/dominion/op-center/index.blade.php
+++ b/app/resources/views/pages/dominion/op-center/index.blade.php
@@ -41,46 +41,43 @@
                             </tr>
                         </thead>
                         <tbody>
-                            @foreach ($targetDominions as $dominion)
-                                @php
-                                    $lastInfoOp = $infoOpService->getLastInfoOp($selectedDominion->realm, $dominion);
-                                @endphp
+                            @foreach ($latestInfoOps as $lastInfoOp)
                                 <tr>
                                     <td>
-                                        <a href="{{ route('dominion.op-center.show', $dominion) }}">{{ $dominion->name }}</a>
+                                        <a href="{{ route('dominion.op-center.show', $lastInfoOp->targetDominion) }}">{{ $lastInfoOp->targetDominion->name }}</a>
                                         @if ($lastInfoOp->isInvalid())
                                             <span class="label label-danger">Invalid</span>
                                         @elseif ($lastInfoOp->isStale())
                                             <span class="label label-warning">Stale</span>
                                         @endif
                                     </td>
-                                    <td data-search="realm:{{ $dominion->realm->number }}">
-                                        <a href="{{ route('dominion.realm', $dominion->realm->number) }}">{{ $dominion->realm->name }} (#{{ $dominion->realm->number }})</a>
+                                    <td data-search="realm:{{ $lastInfoOp->targetDominion->realm->number }}">
+                                        <a href="{{ route('dominion.realm', $lastInfoOp->targetDominion->realm->number) }}">{{ $lastInfoOp->targetDominion->realm->name }} (#{{ $lastInfoOp->targetDominion->realm->number }})</a>
                                         {{-- todo: highlight clicked dominion in realm page? --}}
                                     </td>
-                                    <td class="text-center" data-search="" data-order="{{ $dominion->race->name }}">
-                                        {{ $dominion->race->name }}
+                                    <td class="text-center" data-search="" data-order="{{ $lastInfoOp->targetDominion->race->name }}">
+                                        {{ $lastInfoOp->targetDominion->race->name }}
                                     </td>
                                     {{--
-                                    <td class="text-center" data-search="" data-order="{{ $infoOpService->getOffensivePower($selectedDominion->realm, $dominion) }}">
-                                        {{ $infoOpService->getOffensivePowerString($selectedDominion->realm, $dominion) }}
+                                    <td class="text-center" data-search="" data-order="{{ $infoOpService->getOffensivePower($selectedDominion->realm, $lastInfoOp->targetDominion) }}">
+                                        {{ $infoOpService->getOffensivePowerString($selectedDominion->realm, $lastInfoOp->targetDominion) }}
                                     </td>
-                                    <td class="text-center" data-search="" data-order="{{ $infoOpService->getDefensivePower($selectedDominion->realm, $dominion) }}">
-                                        {{ $infoOpService->getDefensivePowerString($selectedDominion->realm, $dominion) }}
+                                    <td class="text-center" data-search="" data-order="{{ $infoOpService->getDefensivePower($selectedDominion->realm, $lastInfoOp->targetDominion) }}">
+                                        {{ $infoOpService->getDefensivePowerString($selectedDominion->realm, $lastInfoOp->targetDominion) }}
                                     </td>
                                     --}}
-                                    <td class="text-center" data-search="" data-order="{{ $infoOpService->getLand($selectedDominion->realm, $dominion) }}">
-                                        {{ $infoOpService->getLandString($selectedDominion->realm, $dominion) }}
+                                    <td class="text-center" data-search="" data-order="{{ $infoOpService->getLand($selectedDominion->realm, $lastInfoOp->targetDominion) }}">
+                                        {{ $infoOpService->getLandString($selectedDominion->realm, $lastInfoOp->targetDominion) }}
                                         <br>
-                                        <span class="small {{ $rangeCalculator->getDominionRangeSpanClass($selectedDominion, $dominion) }}">
-                                            {{ number_format($rangeCalculator->getDominionRange($selectedDominion, $dominion), 1) }}%
+                                        <span class="small {{ $rangeCalculator->getDominionRangeSpanClass($selectedDominion, $lastInfoOp->targetDominion) }}">
+                                            {{ number_format($rangeCalculator->getDominionRange($selectedDominion, $lastInfoOp->targetDominion), 1) }}%
                                         </span>
                                     </td>
-                                    <td class="text-center" data-search="" data-order="{{ $infoOpService->getNetworth($selectedDominion->realm, $dominion) }}">
-                                        {{ $infoOpService->getNetworthString($selectedDominion->realm, $dominion) }}
+                                    <td class="text-center" data-search="" data-order="{{ $infoOpService->getNetworth($selectedDominion->realm, $lastInfoOp->targetDominion) }}">
+                                        {{ $infoOpService->getNetworthString($selectedDominion->realm, $lastInfoOp->targetDominion) }}
                                     </td>
-                                    <td class="text-center" data-search="" data-order="{{ $lastInfoOp->updated_at->getTimestamp() }}">
-                                        {{ $infoOpService->getLastInfoOpName($selectedDominion->realm, $dominion) }}
+                                    <td class="text-center" data-search="" data-order="{{ $lastInfoOp->created_at->getTimestamp() }}">
+                                        {{ $infoOpService->getLastInfoOpName($selectedDominion->realm, $lastInfoOp->targetDominion) }}
                                         by
                                         @if ($lastInfoOp->sourceDominion->id === $selectedDominion->id)
                                             <strong>
@@ -91,11 +88,11 @@
                                         @endif
                                         <br>
                                         <span class="small">
-                                            {{ $lastInfoOp->updated_at }}
+                                            {{ $lastInfoOp->created_at }}
                                         </span>
                                     </td>
-                                    <td class="text-center" data-search="" data-order="{{ $infoOpService->getNumberOfActiveInfoOps($selectedDominion->realm, $dominion) }}">
-                                        {{ $infoOpService->getNumberOfActiveInfoOps($selectedDominion->realm, $dominion) }}/{{ $infoOpService->getMaxInfoOps() }}
+                                    <td class="text-center" data-search="" data-order="{{ $infoOpService->getNumberOfActiveInfoOps($selectedDominion->realm, $lastInfoOp->targetDominion) }}">
+                                        {{ $infoOpService->getNumberOfActiveInfoOps($selectedDominion->realm, $lastInfoOp->targetDominion) }}/{{ $infoOpService->getMaxInfoOps() }}
                                     </td>
                                 </tr>
                             @endforeach
@@ -134,7 +131,7 @@
                                     <td data-order="{{ $lastInfoOp->targetDominion->name }}">
                                         <a href="{{ route('dominion.op-center.show', $lastInfoOp->targetDominion) }}">{{ $lastInfoOp->targetDominion->name }}</a>
                                     </td>
-                                    <td class="text-center" data-search="" data-order="{{ $lastInfoOp->updated_at->getTimestamp() }}">
+                                    <td class="text-center" data-search="" data-order="{{ $lastInfoOp->created_at->getTimestamp() }}">
                                         Clairvoyance by
                                         @if ($lastInfoOp->sourceDominion->id === $selectedDominion->id)
                                             <strong>
@@ -145,7 +142,7 @@
                                         @endif
                                         <br>
                                         <span class="small">
-                                            {{ $lastInfoOp->updated_at->diffForHumans() }}
+                                            {{ $lastInfoOp->created_at->diffForHumans() }}
                                         </span>
                                     </td>
                                 </tr>
@@ -185,7 +182,7 @@
     <script type="text/javascript">
         (function ($) {
             $('#dominions-table').DataTable({
-                order: [[6, 'desc']],
+                order: [[5, 'desc']],
             });
         })(jQuery);
     </script>

--- a/app/resources/views/pages/dominion/op-center/show.blade.php
+++ b/app/resources/views/pages/dominion/op-center/show.blade.php
@@ -193,7 +193,9 @@
                 @slot('boxFooter')
                     @if ($infoOp !== null)
                         <em>Revealed {{ $infoOp->updated_at }} by {{ $infoOp->sourceDominion->name }}</em>
-                        @if ($infoOp->isStale())
+                        @if ($infoOp->isInvalid())
+                            <span class="label label-danger">Invalid</span>
+                        @elseif ($infoOp->isStale())
                             <span class="label label-warning">Stale</span>
                         @endif
                     @endif
@@ -223,7 +225,7 @@
                 <div class="box-body">
                     <p>This page contains the data that your realmies have gathered about dominion <b>{{ $dominion->name }}</b> from realm {{ $dominion->realm->name }} (#{{ $dominion->realm->number }}).</p>
 
-                    <p>Sections marked as <span class="label label-warning">stale</span> contain data from the previous hour (or earlier) and should be considered inaccurate. Recast your info ops before performing any offensive operations during this hour.</p>
+                    <p>Sections marked as <span class="label label-warning">stale</span> contain data from the previous hour (or earlier) and should be considered inaccurate. Sections marked as <span class="label label-danger">invalid</span> are more than 12 hours old. Recast your info ops before performing any offensive operations during this hour.</p>
 
                     {{--<p>Estimated stats:</p>
                     <p>
@@ -293,7 +295,9 @@
                 @slot('boxFooter')
                     @if ($infoOp !== null)
                         <em>Revealed {{ $infoOp->updated_at }} by {{ $infoOp->sourceDominion->name }}</em>
-                        @if ($infoOp->isStale())
+                        @if ($infoOp->isInvalid())
+                            <span class="label label-danger">Invalid</span>
+                        @elseif ($infoOp->isStale())
                             <span class="label label-warning">Stale</span>
                         @endif
                     @endif
@@ -367,7 +371,9 @@
                 @slot('boxFooter')
                     @if ($infoOp !== null)
                         <em>Revealed {{ $infoOp->updated_at }} by {{ $infoOp->sourceDominion->name }}</em>
-                        @if ($infoOp->isStale())
+                        @if ($infoOp->isInvalid())
+                            <span class="label label-danger">Invalid</span>
+                        @elseif ($infoOp->isStale())
                             <span class="label label-warning">Stale</span>
                         @endif
                     @endif
@@ -473,7 +479,9 @@
                 @slot('boxFooter')
                     @if ($infoOp !== null)
                         <em>Revealed {{ $infoOp->updated_at }} by {{ $infoOp->sourceDominion->name }}</em>
-                        @if ($infoOp->isStale())
+                        @if ($infoOp->isInvalid())
+                            <span class="label label-danger">Invalid</span>
+                        @elseif ($infoOp->isStale())
                             <span class="label label-warning">Stale</span>
                         @endif
                     @endif
@@ -616,7 +624,9 @@
                 @slot('boxFooter')
                     @if ($infoOp !== null)
                         <em>Revealed {{ $infoOp->updated_at }} by {{ $infoOp->sourceDominion->name }}</em>
-                        @if ($infoOp->isStale())
+                        @if ($infoOp->isInvalid())
+                            <span class="label label-danger">Invalid</span>
+                        @elseif ($infoOp->isStale())
                             <span class="label label-warning">Stale</span>
                         @endif
                     @endif
@@ -755,7 +765,9 @@
                 @slot('boxFooter')
                     @if ($infoOp !== null)
                         <em>Revealed {{ $infoOp->updated_at }} by {{ $infoOp->sourceDominion->name }}</em>
-                        @if ($infoOp->isStale())
+                        @if ($infoOp->isInvalid())
+                            <span class="label label-danger">Invalid</span>
+                        @elseif ($infoOp->isStale())
                             <span class="label label-warning">Stale</span>
                         @endif
                     @endif

--- a/app/resources/views/pages/dominion/op-center/show.blade.php
+++ b/app/resources/views/pages/dominion/op-center/show.blade.php
@@ -4,7 +4,6 @@
 
 @section('content')
     <div class="row">
-
         <div class="col-sm-12 col-md-9">
             @component('partials.dominion.op-center.box')
                 @php
@@ -489,7 +488,7 @@
                     <div class="clearfix"></div>
 
                     <div class="text-center">
-                        <a href="{{ route('dominion.op-center.archive', [$dominion, 'barracks_spy']) }}">View Archives
+                        <a href="{{ route('dominion.op-center.archive', [$dominion, 'barracks_spy']) }}">View Archives</a>
                     </div>
                 @endslot
             @endcomponent
@@ -844,41 +843,5 @@
                 @endif
             @endcomponent
         </div>
-    </div>
-
-    <div class="row">
-        <div class="col-sm-12 col-sm-6">
-            @component('partials.dominion.op-center.box')
-                @php
-                    $infoOp = $infoOpService->getInfoOp($selectedDominion->realm, $dominion, 'clairvoyance');
-                @endphp
-
-                @slot('title', 'Town Crier')
-                @slot('titleIconClass', 'fa fa-newspaper-o')
-
-                @if ($infoOp === null)
-                    <p>No recent data available.</p>
-                    <p>Cast magic spell 'Clairvoyance' to reveal information.</p>
-                @else
-                    <a href="{{ route('dominion.op-center.clairvoyance', $dominion->realm->id) }}">{{ $dominion->realm->name }} (#{{ $dominion->realm->number }})</a>
-                    - <em>Revealed <abbr title="{{ $infoOp->updated_at }}">{{ $infoOp->updated_at->diffForHumans() }}</abbr> by {{ $infoOp->sourceDominion->name }}</em>
-                    @if ($infoOp->isStale())
-                        <span class="label label-warning">Stale</span>
-                    @endif
-                @endif
-
-                @slot('boxFooter')
-                    <div class="pull-right">
-                        <form action="{{ route('dominion.magic') }}" method="post" role="form">
-                            @csrf
-                            <input type="hidden" name="target_dominion" value="{{ $dominion->id }}">
-                            <input type="hidden" name="spell" value="clairvoyance">
-                            <button type="submit" class="btn btn-sm btn-primary">Clairvoyance ({{ number_format($spellCalculator->getManaCost($selectedDominion, 'clairvoyance')) }} mana)</button>
-                        </form>
-                    </div>
-                @endslot
-            @endcomponent
-        </div>
-
     </div>
 @endsection

--- a/app/resources/views/pages/dominion/op-center/show.blade.php
+++ b/app/resources/views/pages/dominion/op-center/show.blade.php
@@ -7,7 +7,7 @@
         <div class="col-sm-12 col-md-9">
             @component('partials.dominion.op-center.box')
                 @php
-                    $infoOp = $infoOpService->getInfoOp($selectedDominion->realm, $dominion, 'clear_sight');
+                    $infoOp = $latestInfoOps->firstWhere('type', 'clear_sight');
                 @endphp
 
                 @slot('title', ('Status Screen (' . $dominion->name . ')'))
@@ -21,6 +21,7 @@
                         $race = OpenDominion\Models\Race::findOrFail($infoOp->data['race_id']);
                     @endphp
 
+                    @slot('tableResponsive', false)
                     @slot('noPadding', true)
 
                     <div class="row">
@@ -243,7 +244,7 @@
         <div class="col-sm-12 col-md-6">
             @component('partials.dominion.op-center.box')
                 @php
-                    $infoOp = $infoOpService->getInfoOp($selectedDominion->realm, $dominion, 'revelation');
+                    $infoOp = $latestInfoOps->firstWhere('type', 'revelation');
                 @endphp
 
                 @slot('title', 'Active Spells')
@@ -317,7 +318,7 @@
         <div class="col-sm-12 col-md-6">
             @component('partials.dominion.op-center.box')
                 @php
-                    $infoOp = $infoOpService->getInfoOp($selectedDominion->realm, $dominion, 'castle_spy');
+                    $infoOp = $latestInfoOps->firstWhere('type', 'castle_spy');
                 @endphp
 
                 @slot('title', 'Improvements')
@@ -394,7 +395,7 @@
         <div class="col-sm-12 col-md-6">
             @component('partials.dominion.op-center.box')
                 @php
-                    $infoOp = $infoOpService->getInfoOp($selectedDominion->realm, $dominion, 'barracks_spy');
+                    $infoOp = $latestInfoOps->firstWhere('type', 'barracks_spy');
                 @endphp
 
                 @slot('title', 'Units in training and home')
@@ -496,7 +497,7 @@
         <div class="col-sm-12 col-md-6">
             @component('partials.dominion.op-center.box')
                 @php
-                    $infoOp = $infoOpService->getInfoOp($selectedDominion->realm, $dominion, 'barracks_spy');
+                    $infoOp = $latestInfoOps->firstWhere('type', 'barracks_spy');
                 @endphp
 
                 @slot('title', 'Units returning from battle')
@@ -565,7 +566,7 @@
         <div class="col-sm-12 col-md-6">
             @component('partials.dominion.op-center.box')
                 @php
-                    $infoOp = $infoOpService->getInfoOp($selectedDominion->realm, $dominion, 'survey_dominion');
+                    $infoOp = $latestInfoOps->firstWhere('type', 'survey_dominion');
                 @endphp
 
                 @slot('title', 'Constructed Buildings')
@@ -640,7 +641,7 @@
         <div class="col-sm-12 col-md-6">
             @component('partials.dominion.op-center.box')
                 @php
-                    $infoOp = $infoOpService->getInfoOp($selectedDominion->realm, $dominion, 'survey_dominion');
+                    $infoOp = $latestInfoOps->firstWhere('type', 'survey_dominion');
                 @endphp
 
                 @slot('title', 'Incoming building breakdown')
@@ -706,7 +707,7 @@
         <div class="col-sm-12 col-md-6">
             @component('partials.dominion.op-center.box')
                 @php
-                    $infoOp = $infoOpService->getInfoOp($selectedDominion->realm, $dominion, 'land_spy');
+                    $infoOp = $latestInfoOps->firstWhere('type', 'land_spy');
                 @endphp
 
                 @slot('title', 'Explored Land')
@@ -779,7 +780,7 @@
         <div class="col-sm-12 col-md-6">
             @component('partials.dominion.op-center.box')
                 @php
-                    $infoOp = $infoOpService->getInfoOp($selectedDominion->realm, $dominion, 'land_spy');
+                    $infoOp = $latestInfoOps->firstWhere('type', 'land_spy');
                 @endphp
 
                 @slot('title', 'Incoming land breakdown')

--- a/app/resources/views/pages/dominion/op-center/show.blade.php
+++ b/app/resources/views/pages/dominion/op-center/show.blade.php
@@ -192,7 +192,7 @@
 
                 @slot('boxFooter')
                     @if ($infoOp !== null)
-                        <em>Revealed {{ $infoOp->updated_at }} by {{ $infoOp->sourceDominion->name }}</em>
+                        <em>Revealed {{ $infoOp->created_at }} by {{ $infoOp->sourceDominion->name }}</em>
                         @if ($infoOp->isInvalid())
                             <span class="label label-danger">Invalid</span>
                         @elseif ($infoOp->isStale())
@@ -294,7 +294,7 @@
 
                 @slot('boxFooter')
                     @if ($infoOp !== null)
-                        <em>Revealed {{ $infoOp->updated_at }} by {{ $infoOp->sourceDominion->name }}</em>
+                        <em>Revealed {{ $infoOp->created_at }} by {{ $infoOp->sourceDominion->name }}</em>
                         @if ($infoOp->isInvalid())
                             <span class="label label-danger">Invalid</span>
                         @elseif ($infoOp->isStale())
@@ -370,7 +370,7 @@
 
                 @slot('boxFooter')
                     @if ($infoOp !== null)
-                        <em>Revealed {{ $infoOp->updated_at }} by {{ $infoOp->sourceDominion->name }}</em>
+                        <em>Revealed {{ $infoOp->created_at }} by {{ $infoOp->sourceDominion->name }}</em>
                         @if ($infoOp->isInvalid())
                             <span class="label label-danger">Invalid</span>
                         @elseif ($infoOp->isStale())
@@ -478,7 +478,7 @@
 
                 @slot('boxFooter')
                     @if ($infoOp !== null)
-                        <em>Revealed {{ $infoOp->updated_at }} by {{ $infoOp->sourceDominion->name }}</em>
+                        <em>Revealed {{ $infoOp->created_at }} by {{ $infoOp->sourceDominion->name }}</em>
                         @if ($infoOp->isInvalid())
                             <span class="label label-danger">Invalid</span>
                         @elseif ($infoOp->isStale())
@@ -623,7 +623,7 @@
 
                 @slot('boxFooter')
                     @if ($infoOp !== null)
-                        <em>Revealed {{ $infoOp->updated_at }} by {{ $infoOp->sourceDominion->name }}</em>
+                        <em>Revealed {{ $infoOp->created_at }} by {{ $infoOp->sourceDominion->name }}</em>
                         @if ($infoOp->isInvalid())
                             <span class="label label-danger">Invalid</span>
                         @elseif ($infoOp->isStale())
@@ -764,7 +764,7 @@
 
                 @slot('boxFooter')
                     @if ($infoOp !== null)
-                        <em>Revealed {{ $infoOp->updated_at }} by {{ $infoOp->sourceDominion->name }}</em>
+                        <em>Revealed {{ $infoOp->created_at }} by {{ $infoOp->sourceDominion->name }}</em>
                         @if ($infoOp->isInvalid())
                             <span class="label label-danger">Invalid</span>
                         @elseif ($infoOp->isStale())

--- a/app/resources/views/pages/dominion/op-center/show.blade.php
+++ b/app/resources/views/pages/dominion/op-center/show.blade.php
@@ -206,6 +206,11 @@
                             <button type="submit" class="btn btn-sm btn-primary">Clear Sight ({{ number_format($spellCalculator->getManaCost($selectedDominion, 'clear_sight')) }} mana)</button>
                         </form>
                     </div>
+                    <div class="clearfix"></div>
+
+                    <div class="text-center">
+                        <a href="{{ route('dominion.op-center.archive', [$dominion, 'clear_sight']) }}">View Archives</a>
+                    </div>
                 @endslot
             @endcomponent
         </div>
@@ -243,7 +248,7 @@
                 @endphp
 
                 @slot('title', 'Active Spells')
-                @slot('titleIconClass', 'ra ra-magic-wand')
+                @slot('titleIconClass', 'ra ra-fairy-wand')
 
                 @if ($infoOp === null)
                     <p>No recent data available.</p>
@@ -300,6 +305,11 @@
                             <input type="hidden" name="spell" value="revelation">
                             <button type="submit" class="btn btn-sm btn-primary">Revelation ({{ number_format($spellCalculator->getManaCost($selectedDominion, 'revelation')) }} mana)</button>
                         </form>
+                    </div>
+                    <div class="clearfix"></div>
+
+                    <div class="text-center">
+                        <a href="{{ route('dominion.op-center.archive', [$dominion, 'revelation']) }}">View Archives</a>
                     </div>
                 @endslot
             @endcomponent
@@ -369,6 +379,11 @@
                             <input type="hidden" name="operation" value="castle_spy">
                             <button type="submit" class="btn btn-sm btn-primary">Castle Spy</button>
                         </form>
+                    </div>
+                    <div class="clearfix"></div>
+
+                    <div class="text-center">
+                        <a href="{{ route('dominion.op-center.archive', [$dominion, 'castle_spy']) }}">View Archives</a>
                     </div>
                 @endslot
             @endcomponent
@@ -463,14 +478,19 @@
                         @endif
                     @endif
 
-                        <div class="pull-right">
-                            <form action="{{ route('dominion.espionage') }}" method="post" role="form">
-                                @csrf
-                                <input type="hidden" name="target_dominion" value="{{ $dominion->id }}">
-                                <input type="hidden" name="operation" value="barracks_spy">
-                                <button type="submit" class="btn btn-sm btn-primary">Barracks Spy</button>
-                            </form>
-                        </div>
+                    <div class="clearfix pull-right">
+                        <form action="{{ route('dominion.espionage') }}" method="post" role="form">
+                            @csrf
+                            <input type="hidden" name="target_dominion" value="{{ $dominion->id }}">
+                            <input type="hidden" name="operation" value="barracks_spy">
+                            <button type="submit" class="btn btn-sm btn-primary">Barracks Spy</button>
+                        </form>
+                    </div>
+                    <div class="clearfix"></div>
+
+                    <div class="text-center">
+                        <a href="{{ route('dominion.op-center.archive', [$dominion, 'barracks_spy']) }}">View Archives
+                    </div>
                 @endslot
             @endcomponent
         </div>
@@ -609,6 +629,11 @@
                             <button type="submit" class="btn btn-sm btn-primary">Survey Dominion</button>
                         </form>
                     </div>
+                    <div class="clearfix"></div>
+
+                    <div class="text-center">
+                        <a href="{{ route('dominion.op-center.archive', [$dominion, 'survey_dominion']) }}">View Archives</a>
+                    </div>
                 @endslot
             @endcomponent
         </div>
@@ -742,6 +767,11 @@
                             <input type="hidden" name="operation" value="land_spy">
                             <button type="submit" class="btn btn-sm btn-primary">Land Spy</button>
                         </form>
+                    </div>
+                    <div class="clearfix"></div>
+
+                    <div class="text-center">
+                        <a href="{{ route('dominion.op-center.archive', [$dominion, 'land_spy']) }}">View Archives</a>
                     </div>
                 @endslot
             @endcomponent

--- a/app/resources/views/pages/dominion/realm.blade.php
+++ b/app/resources/views/pages/dominion/realm.blade.php
@@ -71,7 +71,11 @@
                                             @if ($dominion->id === $selectedDominion->id)
                                                 <b>{{ $dominion->name }}</b> (you)
                                             @else
-                                                {{ $dominion->name }}
+                                                @if ($isOwnRealm)
+                                                    {{ $dominion->name }}
+                                                @else
+                                                    <a href="{{ route('dominion.op-center.show', $dominion) }}">{{ $dominion->name }}</a>
+                                                @endif
                                             @endif
 
                                             @if ($isOwnRealm && $dominion->round->isActive() && $dominion->user->isOnline())

--- a/app/resources/views/partials/dominion/op-center/box.blade.php
+++ b/app/resources/views/partials/dominion/op-center/box.blade.php
@@ -9,7 +9,7 @@
         @endisset
     </div>
 
-    <div class="box-body table-responsive {{ (isset($noPadding) && $noPadding) ? 'no-padding' : null }}">
+    <div class="box-body {{ (isset($tableResponsive) && !$tableResponsive) ? null : 'table-responsive' }} {{ (isset($noPadding) && $noPadding) ? 'no-padding' : null }}">
         {{ $slot }}
     </div>
 

--- a/app/resources/views/partials/dominion/op-center/box.blade.php
+++ b/app/resources/views/partials/dominion/op-center/box.blade.php
@@ -9,7 +9,7 @@
         @endisset
     </div>
 
-    <div class="box-body {{ (isset($noPadding) && $noPadding) ? 'no-padding' : null }}">
+    <div class="box-body table-responsive {{ (isset($noPadding) && $noPadding) ? 'no-padding' : null }}">
         {{ $slot }}
     </div>
 

--- a/app/routes/web.php
+++ b/app/routes/web.php
@@ -141,6 +141,7 @@ $router->group(['middleware' => 'auth'], function (Router $router) {
             // Op Center
             $router->get('op-center')->uses('Dominion\OpCenterController@getIndex')->name('op-center');
             $router->get('op-center/{dominion}')->uses('Dominion\OpCenterController@getDominion')->name('op-center.show');
+            $router->get('op-center/{dominion}/{type}')->uses('Dominion\OpCenterController@getDominionArchive')->name('op-center.archive');
             $router->get('op-center/clairvoyance/{realmNumber}')->uses('Dominion\OpCenterController@getClairvoyance')->name('op-center.clairvoyance');
 
             // Rankings

--- a/src/Events/InfoOpCreatingEvent.php
+++ b/src/Events/InfoOpCreatingEvent.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace OpenDominion\Events;
+
+use Illuminate\Queue\SerializesModels;
+use OpenDominion\Models\InfoOp;
+
+class InfoOpCreatingEvent
+{
+    use SerializesModels;
+
+    public $infoOp;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param \OpenDominion\Models\InfoOp
+     * @return void
+     */
+    public function __construct(InfoOp $infoOp)
+    {
+        $this->infoOp = $infoOp;
+    }
+}

--- a/src/Http/Controllers/Dominion/OpCenterController.php
+++ b/src/Http/Controllers/Dominion/OpCenterController.php
@@ -28,12 +28,15 @@ class OpCenterController extends AbstractDominionController
             });
 
         $latestInfoOps = $dominion->realm->infoOps()
+            ->with('sourceDominion')
             ->with('targetDominion')
+            ->with('targetDominion.race')
+            ->with('targetDominion.realm')
             ->where('type', '!=', 'clairvoyance')
             ->where('latest', '=', true)
             ->orderBy('created_at', 'desc')
-            ->groupBy('target_dominion_id')
-            ->get();
+            ->get()
+            ->groupBy('target_dominion_id');
 
         return view('pages.dominion.op-center.index', [
             'infoOpService' => app(InfoOpService::class),
@@ -116,6 +119,7 @@ class OpCenterController extends AbstractDominionController
             $targetRealm,
             'clairvoyance'
         );
+        die(var_dump($clairvoyanceInfoOp));
 
         if ($clairvoyanceInfoOp === null) {
             abort(404);

--- a/src/Http/Controllers/Dominion/OpCenterController.php
+++ b/src/Http/Controllers/Dominion/OpCenterController.php
@@ -58,6 +58,32 @@ class OpCenterController extends AbstractDominionController
         ]);
     }
 
+    public function getDominionArchive(Dominion $dominion, string $type)
+    {
+        $valid_types = ['clear_sight', 'revelation', 'barracks_spy', 'castle_spy', 'survey_dominion', 'land_spy'];
+        $infoOpService = app(InfoOpService::class);
+
+        if (!in_array($type, $valid_types)) {
+            return redirect()->route('dominion.op-center.show', $dominion);
+        }
+
+        $infoOpArchive = $infoOpService->getInfoOpArchive($this->getSelectedDominion()->realm, $dominion, $type);
+
+        return view('pages.dominion.op-center.archive', [
+            'buildingHelper' => app(BuildingHelper::class),
+            'improvementHelper' => app(ImprovementHelper::class),
+            'infoOpService' => app(InfoOpService::class),
+            'landCalculator' => app(LandCalculator::class),
+            'landHelper' => app(LandHelper::class),
+            'rangeCalculator' => app(RangeCalculator::class),
+            'spellCalculator' => app(SpellCalculator::class),
+            'spellHelper' => app(SpellHelper::class),
+            'unitHelper' => app(UnitHelper::class),
+            'dominion' => $dominion,
+            'infoOpArchive' => $infoOpArchive
+        ]);
+    }
+
     public function getClairvoyance(int $realmId)
     {
         $infoOpService = app(InfoOpService::class);

--- a/src/Http/Controllers/Dominion/OpCenterController.php
+++ b/src/Http/Controllers/Dominion/OpCenterController.php
@@ -78,7 +78,7 @@ class OpCenterController extends AbstractDominionController
 
     public function getDominionArchive(Dominion $dominion, string $type)
     {
-        $resultsPerPage = 20;
+        $resultsPerPage = 10;
         $valid_types = ['clear_sight', 'revelation', 'barracks_spy', 'castle_spy', 'survey_dominion', 'land_spy'];
         $infoOpService = app(InfoOpService::class);
 
@@ -91,7 +91,7 @@ class OpCenterController extends AbstractDominionController
             ->with('sourceDominion')
             ->where('target_dominion_id', '=', $dominion->id)
             ->where('type', '=', $type)
-            ->orderBy('updated_at', 'desc')
+            ->orderBy('created_at', 'desc')
             ->paginate($resultsPerPage);
 
         return view('pages.dominion.op-center.archive', [
@@ -119,14 +119,13 @@ class OpCenterController extends AbstractDominionController
             $targetRealm,
             'clairvoyance'
         );
-        die(var_dump($clairvoyanceInfoOp));
 
         if ($clairvoyanceInfoOp === null) {
             abort(404);
         }
 
         $gameEventService = app(GameEventService::class);
-        $clairvoyanceData = $gameEventService->getClairvoyance($targetRealm, $clairvoyanceInfoOp->updated_at);
+        $clairvoyanceData = $gameEventService->getClairvoyance($targetRealm, $clairvoyanceInfoOp->created_at);
 
         $gameEvents = $clairvoyanceData['gameEvents'];
         $dominionIds = $clairvoyanceData['dominionIds'];

--- a/src/Http/Controllers/Dominion/OpCenterController.php
+++ b/src/Http/Controllers/Dominion/OpCenterController.php
@@ -48,7 +48,7 @@ class OpCenterController extends AbstractDominionController
             ->infoOps()
             ->with('sourceDominion')
             ->where('target_dominion_id', '=', $dominion->id)
-            //->where('latest', '=', true);
+            ->where('latest', '=', true)
             ->get();
 
         return view('pages.dominion.op-center.show', [

--- a/src/Http/Controllers/Dominion/OpCenterController.php
+++ b/src/Http/Controllers/Dominion/OpCenterController.php
@@ -44,6 +44,13 @@ class OpCenterController extends AbstractDominionController
             return redirect()->route('dominion.op-center');
         }
 
+        $latestInfoOps = $this->getSelectedDominion()->realm
+            ->infoOps()
+            ->with('sourceDominion')
+            ->where('target_dominion_id', '=', $dominion->id)
+            //->where('latest', '=', true);
+            ->get();
+
         return view('pages.dominion.op-center.show', [
             'buildingHelper' => app(BuildingHelper::class),
             'improvementHelper' => app(ImprovementHelper::class),
@@ -55,6 +62,7 @@ class OpCenterController extends AbstractDominionController
             'spellHelper' => app(SpellHelper::class),
             'unitHelper' => app(UnitHelper::class),
             'dominion' => $dominion,
+            'latestInfoOps' => $latestInfoOps
         ]);
     }
 
@@ -70,6 +78,7 @@ class OpCenterController extends AbstractDominionController
 
         $infoOpArchive = $this->getSelectedDominion()->realm
             ->infoOps()
+            ->with('sourceDominion')
             ->where('target_dominion_id', '=', $dominion->id)
             ->where('type', '=', $type)
             ->orderBy('updated_at', 'desc')

--- a/src/Http/Controllers/Dominion/OpCenterController.php
+++ b/src/Http/Controllers/Dominion/OpCenterController.php
@@ -60,6 +60,7 @@ class OpCenterController extends AbstractDominionController
 
     public function getDominionArchive(Dominion $dominion, string $type)
     {
+        $resultsPerPage = 20;
         $valid_types = ['clear_sight', 'revelation', 'barracks_spy', 'castle_spy', 'survey_dominion', 'land_spy'];
         $infoOpService = app(InfoOpService::class);
 
@@ -67,7 +68,12 @@ class OpCenterController extends AbstractDominionController
             return redirect()->route('dominion.op-center.show', $dominion);
         }
 
-        $infoOpArchive = $infoOpService->getInfoOpArchive($this->getSelectedDominion()->realm, $dominion, $type);
+        $infoOpArchive = $this->getSelectedDominion()->realm
+            ->infoOps()
+            ->where('target_dominion_id', '=', $dominion->id)
+            ->where('type', '=', $type)
+            ->orderBy('updated_at', 'desc')
+            ->paginate($resultsPerPage);
 
         return view('pages.dominion.op-center.archive', [
             'buildingHelper' => app(BuildingHelper::class),

--- a/src/Listeners/InfoOpCreating.php
+++ b/src/Listeners/InfoOpCreating.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace OpenDominion\Listeners;
+
+use OpenDominion\Events\InfoOpCreatingEvent;
+use OpenDominion\Models\InfoOp;
+
+class InfoOpCreating
+{
+    /**
+     * Handle the event.
+     *
+     * @param  InfoOpCreatingEvent  $event
+     * @return void
+     */
+    public function handle(InfoOpCreatingEvent $event)
+    {
+        InfoOp::where('target_dominion_id', '=', $event->infoOp->target_dominion_id)
+            ->where('source_realm_id', '=', $event->infoOp->source_realm_id)
+            ->where('type', '=', $event->infoOp->type)
+            ->update(['latest' => false]);
+    }
+}

--- a/src/Models/InfoOp.php
+++ b/src/Models/InfoOp.php
@@ -69,9 +69,4 @@ class InfoOp extends AbstractModel
     {
         return ($this->updated_at < new Carbon('-12 hours'));
     }
-
-    public function isArchived(): bool
-    {
-        return ($this->updated_at < new Carbon('-72 hours'));
-    }
 }

--- a/src/Models/InfoOp.php
+++ b/src/Models/InfoOp.php
@@ -30,6 +30,10 @@ class InfoOp extends AbstractModel
         'data' => 'array',
     ];
 
+    protected $dispatchesEvents = [
+        'creating' => \OpenDominion\Events\InfoOpCreatingEvent::class,
+    ];
+
     public function sourceRealm()
     {
 //        return $this->belongsTo(Realm::class);

--- a/src/Models/InfoOp.php
+++ b/src/Models/InfoOp.php
@@ -56,7 +56,7 @@ class InfoOp extends AbstractModel
 
 //    public function scopeNotInvalid(Builder $query): Builder
 //    {
-//        return $query->where('updated_at', '>=', now()->parse('-12 hours')->toDateTimeString());
+//        return $query->where('created_at', '>=', now()->parse('-12 hours')->toDateTimeString());
 //    }
 //
 //    public function scopeTargetDominion(Builder $query, Dominion $target): Builder
@@ -66,11 +66,11 @@ class InfoOp extends AbstractModel
 
     public function isStale(): bool
     {
-        return ($this->updated_at < carbon()->minute(0)->second(0));
+        return ($this->created_at < carbon()->minute(0)->second(0));
     }
 
     public function isInvalid(): bool
     {
-        return ($this->updated_at < new Carbon('-12 hours'));
+        return ($this->created_at < new Carbon('-12 hours'));
     }
 }

--- a/src/Models/InfoOp.php
+++ b/src/Models/InfoOp.php
@@ -69,4 +69,9 @@ class InfoOp extends AbstractModel
     {
         return ($this->updated_at < new Carbon('-12 hours'));
     }
+
+    public function isArchived(): bool
+    {
+        return ($this->updated_at < new Carbon('-72 hours'));
+    }
 }

--- a/src/Models/Realm.php
+++ b/src/Models/Realm.php
@@ -62,7 +62,7 @@ class Realm extends AbstractModel
             'target_dominion_id'
         )
             ->groupBy('target_dominion_id')
-            ->orderBy('info_ops.updated_at', 'desc');
+            ->orderBy('info_ops.created_at', 'desc');
     }
 
     public function monarch()

--- a/src/Providers/EventServiceProvider.php
+++ b/src/Providers/EventServiceProvider.php
@@ -3,9 +3,11 @@
 namespace OpenDominion\Providers;
 
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+use OpenDominion\Events\InfoOpCreatingEvent;
 use OpenDominion\Events\UserRegisteredEvent;
 use OpenDominion\Listeners\SendUserRegistrationNotification;
 use OpenDominion\Listeners\SetUserDefaultSettings;
+use OpenDominion\Listeners\InfoOpCreating;
 use OpenDominion\Listeners\Subscribers\ActivitySubscriber;
 use OpenDominion\Listeners\Subscribers\AnalyticsSubscriber;
 
@@ -17,6 +19,9 @@ class EventServiceProvider extends ServiceProvider
      * @var array
      */
     protected $listen = [
+        InfoOpCreatingEvent::class => [
+            InfoOpCreating::class,
+        ],
         UserRegisteredEvent::class => [
             SetUserDefaultSettings::class,
             SendUserRegistrationNotification::class,

--- a/src/Providers/EventServiceProvider.php
+++ b/src/Providers/EventServiceProvider.php
@@ -5,9 +5,9 @@ namespace OpenDominion\Providers;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 use OpenDominion\Events\InfoOpCreatingEvent;
 use OpenDominion\Events\UserRegisteredEvent;
+use OpenDominion\Listeners\InfoOpCreating;
 use OpenDominion\Listeners\SendUserRegistrationNotification;
 use OpenDominion\Listeners\SetUserDefaultSettings;
-use OpenDominion\Listeners\InfoOpCreating;
 use OpenDominion\Listeners\Subscribers\ActivitySubscriber;
 use OpenDominion\Listeners\Subscribers\AnalyticsSubscriber;
 

--- a/src/Services/Dominion/Actions/EspionageActionService.php
+++ b/src/Services/Dominion/Actions/EspionageActionService.php
@@ -233,18 +233,12 @@ class EspionageActionService
         }
 
         // todo: is not invalid?
-        $infoOp = InfoOp::firstOrNew([
+        $infoOp = new InfoOp([
             'source_realm_id' => $dominion->realm->id,
             'target_dominion_id' => $target->id,
             'type' => $operationKey,
-        ], [
             'source_dominion_id' => $dominion->id,
         ]);
-
-        if ($infoOp->exists) {
-            // Overwrite casted_by_dominion_id for the newer data
-            $infoOp->source_dominion_id = $dominion->id;
-        }
 
         switch ($operationKey) {
             case 'barracks_spy':
@@ -375,8 +369,6 @@ class EspionageActionService
                 throw new LogicException("Unknown info gathering operation {$operationKey}");
         }
 
-        // Always force update updated_at on infoops to know when the last infoop was performed
-        $infoOp->updated_at = now(); // todo: fixable with ->save(['touch'])?
         $infoOp->save();
 
         return [

--- a/src/Services/Dominion/Actions/EspionageActionService.php
+++ b/src/Services/Dominion/Actions/EspionageActionService.php
@@ -232,7 +232,6 @@ class EspionageActionService
             }
         }
 
-        // todo: is not invalid?
         $infoOp = new InfoOp([
             'source_realm_id' => $dominion->realm->id,
             'target_dominion_id' => $target->id,

--- a/src/Services/Dominion/Actions/SpellActionService.php
+++ b/src/Services/Dominion/Actions/SpellActionService.php
@@ -277,31 +277,13 @@ class SpellActionService
 
         // todo: take Energy Mirror into account with 20% spell reflect (either show your info or give the infoop to the target)
 
-        if ($spellKey === 'clairvoyance') {
-            $infoOp = InfoOp::firstOrNew([
-                'source_realm_id' => $dominion->realm->id,
-                'target_realm_id' => $target->realm->id,
-                'type' => $spellKey,
-            ], [
-                'source_dominion_id' => $dominion->id,
-                'target_dominion_id' => $target->id,
-            ]);
-        } else {
-            $infoOp = InfoOp::firstOrNew([
-                'source_realm_id' => $dominion->realm->id,
-                'target_dominion_id' => $target->id,
-                'type' => $spellKey,
-            ], [
-                'target_realm_id' => $target->realm->id,
-                'source_dominion_id' => $dominion->id,
-            ]);
-        }
-
-        if ($infoOp->exists) {
-            // Overwrite casted_by_dominion_id for the newer data
-            $infoOp->source_dominion_id = $dominion->id;
-            $infoOp->target_dominion_id = $target->id;
-        }
+        $infoOp = new InfoOp([
+            'source_realm_id' => $dominion->realm->id,
+            'target_realm_id' => $target->realm->id,
+            'type' => $spellKey,
+            'source_dominion_id' => $dominion->id,
+            'target_dominion_id' => $target->id,
+        ]);
 
         switch ($spellKey) {
             case 'clear_sight':
@@ -361,8 +343,6 @@ class SpellActionService
                 throw new LogicException("Unknown info op spell {$spellKey}");
         }
 
-        // Always force update updated_at on infoops to know when the last infoop was cast
-        $infoOp->updated_at = now(); // todo: fixable with ->save(['touch'])?
         $infoOp->save();
 
         $redirect = route('dominion.op-center.show', $target);

--- a/src/Services/Dominion/InfoOpService.php
+++ b/src/Services/Dominion/InfoOpService.php
@@ -34,12 +34,10 @@ class InfoOpService
 //        return ($sourceRealm
 //                ->infoOps()
 //                ->targetDominion($targetDominion)
-//                ->notInvalid()
 //                ->count() > 0);
 
         return ($sourceRealm->infoOps->filter(function (InfoOp $infoOp) use ($targetDominion) {
                 return (
-                    !$infoOp->isInvalid() &&
                     ($infoOp->target_dominion_id === $targetDominion->id)
                 );
             })->count() > 0);
@@ -51,12 +49,10 @@ class InfoOpService
 //                ->infoOps()
 //                ->targetDominion($targetDominion)
 //                ->whereType($type)
-//                ->notInvalid()
 //                ->count() === 1);
 
         return ($sourceRealm->infoOps->filter(function (InfoOp $infoOp) use ($targetDominion, $type) {
                 return (
-                    !$infoOp->isInvalid() &&
                     ($infoOp->target_dominion_id === $targetDominion->id) &&
                     ($infoOp->type === $type)
                 );
@@ -67,7 +63,6 @@ class InfoOpService
     {
         return $sourceRealm->infoOps->filter(function (InfoOp $infoOp) use ($targetDominion, $type) {
             return (
-                !$infoOp->isInvalid() &&
                 ($infoOp->target_dominion_id === $targetDominion->id) &&
                 ($infoOp->type === $type)
             );
@@ -78,7 +73,6 @@ class InfoOpService
     {
         return $sourceRealm->infoOps->filter(function (InfoOp $infoOp) use ($targetRealm, $type) {
             return (
-                !$infoOp->isInvalid() &&
                 ($infoOp->type === $type) &&
                 $infoOp->target_realm_id == $targetRealm->id
             );

--- a/src/Services/Dominion/InfoOpService.php
+++ b/src/Services/Dominion/InfoOpService.php
@@ -31,11 +31,6 @@ class InfoOpService
 
     public function hasInfoOps(Realm $sourceRealm, Dominion $targetDominion): bool
     {
-//        return ($sourceRealm
-//                ->infoOps()
-//                ->targetDominion($targetDominion)
-//                ->count() > 0);
-
         return ($sourceRealm->infoOps->filter(function (InfoOp $infoOp) use ($targetDominion) {
                 return (
                     ($infoOp->target_dominion_id === $targetDominion->id)
@@ -45,18 +40,12 @@ class InfoOpService
 
     public function hasInfoOp(Realm $sourceRealm, Dominion $targetDominion, string $type): bool
     {
-//        return ($sourceRealm
-//                ->infoOps()
-//                ->targetDominion($targetDominion)
-//                ->whereType($type)
-//                ->count() === 1);
-
         return ($sourceRealm->infoOps->filter(function (InfoOp $infoOp) use ($targetDominion, $type) {
                 return (
                     ($infoOp->target_dominion_id === $targetDominion->id) &&
                     ($infoOp->type === $type)
                 );
-            })->count() === 1);
+            })->count() > 0);
     }
 
     public function getInfoOp(Realm $sourceRealm, Dominion $targetDominion, string $type): ?InfoOp
@@ -66,7 +55,7 @@ class InfoOpService
                 ($infoOp->target_dominion_id === $targetDominion->id) &&
                 ($infoOp->type === $type)
             );
-        })->sortByDesc('updated_at')->first();
+        })->sortByDesc('created_at')->first();
     }
 
     public function getInfoOpForRealm(Realm $sourceRealm, Realm $targetRealm, string $type): ?InfoOp
@@ -76,7 +65,7 @@ class InfoOpService
                 ($infoOp->type === $type) &&
                 $infoOp->target_realm_id == $targetRealm->id
             );
-        })->sortByDesc('updated_at')->first();
+        })->sortByDesc('created_at')->first();
     }
 
     public function getOffensivePower(Realm $sourceRealm, Dominion $targetDominion): ?int
@@ -185,7 +174,7 @@ class InfoOpService
         return $sourceRealm->infoOps->filter(function ($infoOp) use ($targetDominion) {
             return ($infoOp->target_dominion_id === $targetDominion->id && $infoOp->type != 'clairvoyance');
         })
-        ->sortByDesc('updated_at')
+        ->sortByDesc('created_at')
         ->first();
     }
 
@@ -206,7 +195,7 @@ class InfoOpService
         return $sourceRealm->infoOps->filter(function ($infoOp) use ($targetRealm) {
             return ($infoOp->target_realm_id === $targetRealm->id && $infoOp->type == 'clairvoyance');
         })
-            ->sortByDesc('updated_at')
+            ->sortByDesc('created_at')
             ->first();
     }
 

--- a/src/Services/Dominion/InfoOpService.php
+++ b/src/Services/Dominion/InfoOpService.php
@@ -71,7 +71,7 @@ class InfoOpService
                 ($infoOp->target_dominion_id === $targetDominion->id) &&
                 ($infoOp->type === $type)
             );
-        })->first();
+        })->sortByDesc('updated_at')->first();
     }
 
     public function getInfoOpForRealm(Realm $sourceRealm, Realm $targetRealm, string $type): ?InfoOp
@@ -82,18 +82,7 @@ class InfoOpService
                 ($infoOp->type === $type) &&
                 $infoOp->target_realm_id == $targetRealm->id
             );
-        })->first();
-    }
-
-    public function getInfoOpArchive(Realm $sourceRealm, Dominion $targetDominion, string $type): Collection
-    {
-        return $sourceRealm->infoOps->filter(function (InfoOp $infoOp) use ($targetDominion, $type) {
-            return (
-                !$infoOp->isArchived() &&
-                ($infoOp->target_dominion_id === $targetDominion->id) &&
-                ($infoOp->type === $type)
-            );
-        })->sortByDesc('created_at');
+        })->sortByDesc('updated_at')->first();
     }
 
     public function getOffensivePower(Realm $sourceRealm, Dominion $targetDominion): ?int
@@ -202,8 +191,8 @@ class InfoOpService
         return $sourceRealm->infoOps->filter(function ($infoOp) use ($targetDominion) {
             return ($infoOp->target_dominion_id === $targetDominion->id && $infoOp->type != 'clairvoyance');
         })
-            ->sortByDesc('updated_at')
-            ->first();
+        ->sortByDesc('updated_at')
+        ->first();
     }
 
     public function getLastInfoOpName(Realm $sourceRealm, Dominion $targetDominion): string

--- a/src/Services/Dominion/InfoOpService.php
+++ b/src/Services/Dominion/InfoOpService.php
@@ -2,6 +2,7 @@
 
 namespace OpenDominion\Services\Dominion;
 
+use Illuminate\Support\Collection;
 use OpenDominion\Helpers\EspionageHelper;
 use OpenDominion\Helpers\SpellHelper;
 use OpenDominion\Models\Dominion;
@@ -82,6 +83,17 @@ class InfoOpService
                 $infoOp->target_realm_id == $targetRealm->id
             );
         })->first();
+    }
+
+    public function getInfoOpArchive(Realm $sourceRealm, Dominion $targetDominion, string $type): Collection
+    {
+        return $sourceRealm->infoOps->filter(function (InfoOp $infoOp) use ($targetDominion, $type) {
+            return (
+                !$infoOp->isArchived() &&
+                ($infoOp->target_dominion_id === $targetDominion->id) &&
+                ($infoOp->type === $type)
+            );
+        })->sortByDesc('created_at');
     }
 
     public function getOffensivePower(Realm $sourceRealm, Dominion $targetDominion): ?int


### PR DESCRIPTION
This was a big one. I'll try to list everything here:

- Added database migration (which evolved a few times) to remove unique constraint for realm/target/type and added a latest boolean with a default value of true
- Added an event listener to set the pre-existing latest op to latest=false (InfoOpCreating)
- **Rewrote and optimized the Op Center queries** 
- Added a paginated archive view for ops older than the latest
- Added 'Invalid' badge to ops older than 12 hours
- Excluded invalid ops from Recent Ops count
- Added Race column to main op center table
- Added links from Realm pages to op center
- Fixed icon on Revelation op box
- Fixed issue with Clear Sight scrollbar

One thing that stands out is that no matter how hard I tried to get a date ordered group by clause to work when querying the latest op for every dominion- it did not work with the ORM. So unfortunately it queries the latest op of each type for every dominion and then uses groupBy on the Collection to reduce that to a single op per dominion. Either way, this appears to be much faster than even what we had before (without multiples).