### PR TITLE
Adjustments for clairvoyance

### DIFF
--- a/app/resources/views/pages/dominion/op-center/index.blade.php
+++ b/app/resources/views/pages/dominion/op-center/index.blade.php
@@ -107,7 +107,7 @@
                     <h3 class="box-title">Clairvoyance Realms</h3>
                 </div>
                 <div class="box-body table-responsive">
-                    <table class="table table-hover" id="dominions-table">
+                    <table class="table table-hover" id="clairvoyance-table">
                         <colgroup>
                             <col>
                             <col>
@@ -127,7 +127,7 @@
                                 @endphp
                                 <tr>
                                     <td data-order="{{ $realm->number }}">
-                                        <a href="{{ route('dominion.op-center.clairvoyance', $realm->id) }}">{{ $realm->name }} (#{{ $realm->number }})</a>
+                                        <a href="{{ route('dominion.op-center.clairvoyance', $realm->number) }}">{{ $realm->name }} (#{{ $realm->number }})</a>
                                     </td>
                                     <td data-order="{{ $lastInfoOp->targetDominion->name }}">
                                         <a href="{{ route('dominion.op-center.show', $lastInfoOp->targetDominion) }}">{{ $lastInfoOp->targetDominion->name }}</a>
@@ -184,6 +184,9 @@
         (function ($) {
             $('#dominions-table').DataTable({
                 order: [[5, 'desc']],
+            });
+            $('#clairvoyance-table').DataTable({
+                order: [[2, 'desc']],
             });
         })(jQuery);
     </script>

--- a/app/resources/views/pages/dominion/op-center/index.blade.php
+++ b/app/resources/views/pages/dominion/op-center/index.blade.php
@@ -121,29 +121,26 @@
                             </tr>
                         </thead>
                         <tbody>
-                            @foreach ($clairvoyanceRealms as $realm)
-                                @php
-                                    $lastInfoOp = $infoOpService->getLastClairvoyance($selectedDominion->realm, $realm);
-                                @endphp
+                            @foreach ($clairvoyances as $clairvoyance)
                                 <tr>
-                                    <td data-order="{{ $realm->number }}">
-                                        <a href="{{ route('dominion.op-center.clairvoyance', $realm->number) }}">{{ $realm->name }} (#{{ $realm->number }})</a>
+                                    <td data-order="{{ $clairvoyance->targetRealm->number }}">
+                                        <a href="{{ route('dominion.op-center.clairvoyance', $clairvoyance->targetRealm->number) }}">{{ $clairvoyance->targetRealm->name }} (#{{ $clairvoyance->targetRealm->number }})</a>
                                     </td>
-                                    <td data-order="{{ $lastInfoOp->targetDominion->name }}">
-                                        <a href="{{ route('dominion.op-center.show', $lastInfoOp->targetDominion) }}">{{ $lastInfoOp->targetDominion->name }}</a>
+                                    <td data-order="{{ $clairvoyance->targetDominion->name }}">
+                                        <a href="{{ route('dominion.op-center.show', $clairvoyance->targetDominion->id) }}">{{ $clairvoyance->targetDominion->name }}</a>
                                     </td>
-                                    <td class="text-center" data-search="" data-order="{{ $lastInfoOp->created_at->getTimestamp() }}">
+                                    <td class="text-center" data-search="" data-order="{{ $clairvoyance->created_at->getTimestamp() }}">
                                         Clairvoyance by
-                                        @if ($lastInfoOp->sourceDominion->id === $selectedDominion->id)
+                                        @if ($clairvoyance->sourceDominion->id === $selectedDominion->id)
                                             <strong>
                                                 {{ $selectedDominion->name }}
                                             </strong>
                                         @else
-                                            {{ $lastInfoOp->sourceDominion->name }}
+                                            {{ $clairvoyance->sourceDominion->name }}
                                         @endif
                                         <br>
                                         <span class="small">
-                                            {{ $lastInfoOp->created_at->diffForHumans() }}
+                                            {{ $clairvoyance->created_at->diffForHumans() }}
                                         </span>
                                     </td>
                                 </tr>

--- a/app/resources/views/pages/dominion/town-crier.blade.php
+++ b/app/resources/views/pages/dominion/town-crier.blade.php
@@ -76,11 +76,11 @@
                                 @endforeach
                             </tbody>
                         </table>
-                        @if ($fromOpCenter)
-                            <div class="box-footer">
-                                <em>Revealed {{ $clairvoyanceInfoOp->updated_at }} by {{ $clairvoyanceInfoOp->sourceDominion->name }}</em>
-                            </div>
-                        @endif
+                    </div>
+                @endif
+                @if ($fromOpCenter)
+                    <div class="box-footer">
+                        <em>Revealed {{ $clairvoyanceInfoOp->updated_at }} by {{ $clairvoyanceInfoOp->sourceDominion->name }}</em>
                     </div>
                 @endif
             </div>

--- a/app/routes/web.php
+++ b/app/routes/web.php
@@ -140,9 +140,9 @@ $router->group(['middleware' => 'auth'], function (Router $router) {
 
             // Op Center
             $router->get('op-center')->uses('Dominion\OpCenterController@getIndex')->name('op-center');
+            $router->get('op-center/clairvoyance/{realmNumber}')->uses('Dominion\OpCenterController@getClairvoyance')->name('op-center.clairvoyance');
             $router->get('op-center/{dominion}')->uses('Dominion\OpCenterController@getDominion')->name('op-center.show');
             $router->get('op-center/{dominion}/{type}')->uses('Dominion\OpCenterController@getDominionArchive')->name('op-center.archive');
-            $router->get('op-center/clairvoyance/{realmNumber}')->uses('Dominion\OpCenterController@getClairvoyance')->name('op-center.clairvoyance');
 
             // Government
             $router->get('government')->uses('Dominion\GovernmentController@getIndex')->name('government');

--- a/src/Http/Controllers/Dominion/OpCenterController.php
+++ b/src/Http/Controllers/Dominion/OpCenterController.php
@@ -25,7 +25,8 @@ class OpCenterController extends AbstractDominionController
             ->get()
             ->map(static function ($infoOp) {
                 return $infoOp->targetRealm;
-            });
+            })
+            ->unique();
 
         $latestInfoOps = $dominion->realm->infoOps()
             ->with('sourceDominion')
@@ -109,10 +110,16 @@ class OpCenterController extends AbstractDominionController
         ]);
     }
 
-    public function getClairvoyance(int $realmId)
+    public function getClairvoyance(int $realmNumber)
     {
         $infoOpService = app(InfoOpService::class);
-        $targetRealm = Realm::findOrFail($realmId);
+        $dominion = $this->getSelectedDominion();
+
+        $targetRealm = Realm::where([
+                'round_id' => $dominion->round->id,
+                'number' => $realmNumber,
+            ])
+            ->firstOrFail();
 
         $clairvoyanceInfoOp = $infoOpService->getInfoOpForRealm(
             $this->getSelectedDominion()->realm,

--- a/src/Http/Controllers/Dominion/OpCenterController.php
+++ b/src/Http/Controllers/Dominion/OpCenterController.php
@@ -20,13 +20,6 @@ class OpCenterController extends AbstractDominionController
     public function getIndex()
     {
         $dominion = $this->getSelectedDominion();
-        $clairvoyanceRealms = $dominion->realm->infoOps()
-            ->where('type', '=', 'clairvoyance')
-            ->get()
-            ->map(static function ($infoOp) {
-                return $infoOp->targetRealm;
-            })
-            ->unique();
 
         $latestInfoOps = $dominion->realm->infoOps()
             ->with('sourceDominion')
@@ -39,12 +32,21 @@ class OpCenterController extends AbstractDominionController
             ->get()
             ->groupBy('target_dominion_id');
 
+        $clairvoyances = $dominion->realm->infoOps()
+            ->with('sourceDominion')
+            ->with('targetDominion')
+            ->with('targetRealm')
+            ->where('type', '=', 'clairvoyance')
+            ->where('latest', '=', true)
+            ->orderBy('created_at', 'desc')
+            ->get();
+
         return view('pages.dominion.op-center.index', [
             'infoOpService' => app(InfoOpService::class),
             'rangeCalculator' => app(RangeCalculator::class),
             'spellHelper' => app(SpellHelper::class),
             'latestInfoOps' => $latestInfoOps,
-            'clairvoyanceRealms' => $clairvoyanceRealms
+            'clairvoyances' => $clairvoyances
         ]);
     }
 

--- a/src/Listeners/InfoOpCreating.php
+++ b/src/Listeners/InfoOpCreating.php
@@ -19,5 +19,10 @@ class InfoOpCreating
             ->where('source_realm_id', '=', $event->infoOp->source_realm_id)
             ->where('type', '=', $event->infoOp->type)
             ->update(['latest' => false]);
+
+        InfoOp::where('target_realm_id', '=', $event->infoOp->target_realm_id)
+            ->where('source_realm_id', '=', $event->infoOp->source_realm_id)
+            ->where('type', '=', 'clairvoyance')
+            ->update(['latest' => false]);
     }
 }

--- a/src/Services/Dominion/Actions/SpellActionService.php
+++ b/src/Services/Dominion/Actions/SpellActionService.php
@@ -364,7 +364,7 @@ class SpellActionService
 
         $redirect = route('dominion.op-center.show', $target);
         if ($spellKey === 'clairvoyance') {
-            $redirect = route('dominion.op-center.clairvoyance', $target->realm->id);
+            $redirect = route('dominion.op-center.clairvoyance', $target->realm->number);
         }
 
         return [

--- a/src/Services/GameEventService.php
+++ b/src/Services/GameEventService.php
@@ -17,9 +17,9 @@ class GameEventService
         return $this->getGameEventsForRealm($realm, now());
     }
 
-    public function getClairvoyance(Realm $realm, Carbon $clairvoyanceUpdateAt): array
+    public function getClairvoyance(Realm $realm, Carbon $clairvoyanceCreatedAt): array
     {
-        return $this->getGameEventsForRealm($realm, $clairvoyanceUpdateAt);
+        return $this->getGameEventsForRealm($realm, $clairvoyanceCreatedAt);
     }
 
     private function getGameEventsForRealm(Realm $realm, Carbon $createdBefore) : array


### PR DESCRIPTION
This needed a little tweaking after allowing multiple ops of the same type.

- Don't display the same realm multiple times
- Fix data table for CV
- Reorder routes (caused 404 on my machine)
- Use realm number instead of ID in URL

This does not currently allow viewing older CVs (needs an info_op id or something in the URL to identify which one you're looking at). Think this is fine for next round?