### PR TITLE
Fix very slow load time for Op Center index

### DIFF
--- a/app/resources/views/pages/dominion/op-center/index.blade.php
+++ b/app/resources/views/pages/dominion/op-center/index.blade.php
@@ -67,15 +67,15 @@
                                         {{ $infoOpService->getDefensivePowerString($selectedDominion->realm, $lastInfoOp->targetDominion) }}
                                     </td>
                                     --}}
-                                    <td class="text-center" data-search="" data-order="{{ $infoOpService->getLand($selectedDominion->realm, $lastInfoOp->targetDominion) }}">
-                                        {{ $infoOpService->getLandString($selectedDominion->realm, $lastInfoOp->targetDominion) }}
+                                    <td class="text-center" data-search="" data-order="{{ $infoOpService->getLand($targetDominionOps) }}">
+                                        {{ $infoOpService->getLandString($targetDominionOps) }}
                                         <br>
                                         <span class="small {{ $rangeCalculator->getDominionRangeSpanClass($selectedDominion, $lastInfoOp->targetDominion) }}">
                                             {{ number_format($rangeCalculator->getDominionRange($selectedDominion, $lastInfoOp->targetDominion), 1) }}%
                                         </span>
                                     </td>
-                                    <td class="text-center" data-search="" data-order="{{ $infoOpService->getNetworth($selectedDominion->realm, $lastInfoOp->targetDominion) }}">
-                                        {{ $infoOpService->getNetworthString($selectedDominion->realm, $lastInfoOp->targetDominion) }}
+                                    <td class="text-center" data-search="" data-order="{{ $infoOpService->getNetworth($targetDominionOps) }}">
+                                        {{ $infoOpService->getNetworthString($targetDominionOps) }}
                                     </td>
                                     <td class="text-center" data-search="" data-order="{{ $lastInfoOp->created_at->getTimestamp() }}">
                                         {{ $infoOpService->getInfoOpName($lastInfoOp) }}
@@ -92,8 +92,8 @@
                                             {{ $lastInfoOp->created_at }}
                                         </span>
                                     </td>
-                                    <td class="text-center" data-search="" data-order="{{ $infoOpService->getNumberOfActiveInfoOps($selectedDominion->realm, $lastInfoOp->targetDominion) }}">
-                                        {{ $infoOpService->getNumberOfActiveInfoOps($selectedDominion->realm, $lastInfoOp->targetDominion) }}/{{ $infoOpService->getMaxInfoOps() }}
+                                    <td class="text-center" data-search="" data-order="{{ $infoOpService->getNumberOfActiveInfoOps($targetDominionOps) }}">
+                                        {{ $infoOpService->getNumberOfActiveInfoOps($targetDominionOps) }}/{{ $infoOpService->getMaxInfoOps() }}
                                     </td>
                                 </tr>
                             @endforeach

--- a/app/resources/views/pages/dominion/op-center/show.blade.php
+++ b/app/resources/views/pages/dominion/op-center/show.blade.php
@@ -231,8 +231,8 @@
                     <p>
                         OP: ??? <abbr title="Not yet implemented" class="label label-danger">NYI</abbr><br>
                         DP: ??? <abbr title="Not yet implemented" class="label label-danger">NYI</abbr><br>
-                        Land: {{ $infoOpService->getLandString($selectedDominion->realm, $dominion) }}<br>
-                        Networth: {{ $infoOpService->getNetworthString($selectedDominion->realm, $dominion) }}<br>
+                        Land: {{ $infoOpService->getLandString($latestInfoOps) }}<br>
+                        Networth: {{ $infoOpService->getNetworthString($latestInfoOps) }}<br>
                     </p>--}}
 
                     {{-- todo: invade button --}}

--- a/src/Services/Dominion/InfoOpService.php
+++ b/src/Services/Dominion/InfoOpService.php
@@ -110,61 +110,63 @@ class InfoOpService
         return 'todo';
     }
 
-    public function getLand(Realm $sourceRealm, Dominion $targetDominion): ?int
+    public function getLand(Collection $ops): ?int
     {
-        if (!$this->hasActiveInfoOp($sourceRealm, $targetDominion, 'clear_sight')) {
-            return null;
+        $clearSight = $ops->filter(function ($op) {
+            return $op->type == 'clear_sight';
+        })->first();
+
+        if ($clearSight) {
+            return $clearSight->data['land'];
         }
 
-        $clearSight = $this->getInfoOp($sourceRealm, $targetDominion, 'clear_sight');
-
-        return $clearSight->data['land'];
+        return null;
     }
 
-    public function getLandString(Realm $sourceRealm, Dominion $targetDominion): string
+    public function getLandString(Collection $ops): string
     {
-        $land = $this->getLand($sourceRealm, $targetDominion);
+        $clearSight = $ops->filter(function ($op) {
+            return $op->type == 'clear_sight';
+        })->first();
 
-        if ($land === null) {
-            return '???';
-        }
-
-        $clearSight = $this->getInfoOp($sourceRealm, $targetDominion, 'clear_sight');
-
-        $return = number_format($clearSight->data['land']);
-
-        if ($clearSight->isStale()) {
-            $return .= '?';
+        if ($clearSight) {
+            $return = number_format($clearSight->data['land']);
+            if ($clearSight->isStale()) {
+                $return .= '?';
+            }
+        } else {
+            $return = '???';
         }
 
         return $return;
     }
 
-    public function getNetworth(Realm $sourceRealm, Dominion $targetDominion): ?int
+    public function getNetworth(Collection $ops): ?int
     {
-        if (!$this->hasActiveInfoOp($sourceRealm, $targetDominion, 'clear_sight')) {
-            return null;
+        $clearSight = $ops->filter(function ($op) {
+            return $op->type == 'clear_sight';
+        })->first();
+
+        if ($clearSight) {
+            return $clearSight->data['networth'];
         }
 
-        $clearSight = $this->getInfoOp($sourceRealm, $targetDominion, 'clear_sight');
-
-        return $clearSight->data['networth'];
+        return null;
     }
 
-    public function getNetworthString(Realm $sourceRealm, Dominion $targetDominion): string
+    public function getNetworthString(Collection $ops): string
     {
-        $networth = $this->getNetworth($sourceRealm, $targetDominion);
+        $clearSight = $ops->filter(function ($op) {
+            return $op->type == 'clear_sight';
+        })->first();
 
-        if ($networth === null) {
-            return '???';
-        }
-
-        $clearSight = $this->getInfoOp($sourceRealm, $targetDominion, 'clear_sight');
-
-        $return = number_format($clearSight->data['networth']);
-
-        if ($clearSight->isStale()) {
-            $return .= '?';
+        if ($clearSight) {
+            $return = number_format($clearSight->data['networth']);
+            if ($clearSight->isStale()) {
+                $return .= '?';
+            }
+        } else {
+            $return = '???';
         }
 
         return $return;
@@ -189,15 +191,10 @@ class InfoOpService
             ->first();
     }
 
-    public function getNumberOfActiveInfoOps(Realm $sourceRealm, Dominion $targetDominion): int
+    public function getNumberOfActiveInfoOps(Collection $ops): int
     {
-        return $this->espionageHelper->getInfoGatheringOperations()
-            ->merge($this->spellHelper->getInfoOpSpells())
-            ->filter(function ($op) use ($sourceRealm, $targetDominion) {
-                if ($op['key'] !== 'clairvoyance') { // refactor: Removes Clairvoyance from count
-                    return $this->hasActiveInfoOp($sourceRealm, $targetDominion, $op['key']);
-                }
-                return null;
+        return $ops->filter(function ($op) {
+                return !$op->isStale();
             })
             ->count();
     }
@@ -205,7 +202,7 @@ class InfoOpService
     public function getMaxInfoOps(): int
     {
         return $this->espionageHelper->getInfoGatheringOperations()
-                ->merge($this->spellHelper->getInfoOpSpells())
-                ->count() - 1; // refactor: Removes Clairvoyance from count
+            ->merge($this->spellHelper->getInfoOpSpells())
+            ->count() - 1; // refactor: Removes Clairvoyance from count
     }
 }


### PR DESCRIPTION
getNetworth, getLand, and getNumberOfActiveInfoOps will now use the collection of infoOps already queried at the controller level instead of looking them up separately.