### PR TITLE
Replace return false to filter when pack is closed with continue.

### DIFF
--- a/src/Services/RealmFinderService.php
+++ b/src/Services/RealmFinderService.php
@@ -54,7 +54,7 @@ class RealmFinderService
                 $availableSlots = ($round->realm_size - $realm->dominions_count);
                 foreach ($realm->packs as $pack) {
                     if ($pack->isClosed()) {
-                        return false;
+                        continue;
                     }
                     $availableSlots -= ($pack->size - $pack->dominions->count());
                 }


### PR DESCRIPTION
## Description
Should continue loop instead if I am not mistaken. Otherwise it should result in false negative to filter?

## Motivation and Context
Solves problem with potential false negatives in filter that selects random realm.

## How Has This Been Tested?
Please advise on how I should be testing this. I can set up and test when I get home. @stromblom could probably check or help me get started.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
