### PR TITLE
Surreal perception shouldn't affect info ops

### DIFF
--- a/src/Services/Dominion/Actions/EspionageActionService.php
+++ b/src/Services/Dominion/Actions/EspionageActionService.php
@@ -397,15 +397,6 @@ class EspionageActionService
 
         $infoOp->save();
 
-        if ($this->spellCalculator->isSpellActive($target, 'surreal_perception')) {
-            $this->notificationService
-                ->queueNotification('received_spy_op', [
-                    'sourceDominionId' => $dominion->id,
-                    'operationKey' => $operationKey,
-                ])
-                ->sendNotifications($target, 'irregular_dominion');
-        }
-
         return [
             'success' => true,
             'message' => 'Your spies infiltrate the target\'s dominion successfully and return with a wealth of information.',

--- a/src/Services/Dominion/Actions/SpellActionService.php
+++ b/src/Services/Dominion/Actions/SpellActionService.php
@@ -360,15 +360,6 @@ class SpellActionService
 
         $infoOp->save();
 
-        if ($this->spellCalculator->isSpellActive($target, 'surreal_perception')) {
-            $this->notificationService
-                ->queueNotification('received_hostile_spell', [
-                    'sourceDominionId' => $dominion->id,
-                    'spellKey' => $spellKey,
-                ])
-                ->sendNotifications($target, 'irregular_dominion');
-        }
-
         $redirect = route('dominion.op-center.show', $target);
         if ($spellKey === 'clairvoyance') {
             $redirect = route('dominion.op-center.clairvoyance', $target->realm->number);


### PR DESCRIPTION
Surreal perception was mistakenly being applied to info ops as well as theft. The scribes specifically state "non-information gathering" ops. https://dominion.opendominion.net/scribes/ops.html