### PR TITLE
Hide other realms before round has started

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/). 
 - Failed invasions when sending over 85% of the target's defense will now properly reduce defensive casualties for subsequent invasions
 - Slightly tweaked starvation casualties to now kill off population types based on proportion
 - Significantly increased the speed of the hourly tick (hour change)
+- Can no longer view other realms before the round starts
 
 ### Fixed
 - Barracks Spy should now be more clear that draftees are inaccurate

--- a/app/resources/views/pages/dominion/search.blade.php
+++ b/app/resources/views/pages/dominion/search.blade.php
@@ -96,40 +96,42 @@
                             </tr>
                         </thead>
                         <tbody>
-                            @foreach ($dominions as $dominion)
-                                <tr>
-                                    <td data-search="{{ $dominion->name }}">
-                                        @if ($protectionService->isUnderProtection($dominion))
-                                            <i class="ra ra-shield ra-lg text-aqua" title="Under Protection"></i>
-                                        @endif
+                            @if ($selectedDominion->round->hasStarted())
+                                @foreach ($dominions as $dominion)
+                                    <tr>
+                                        <td data-search="{{ $dominion->name }}">
+                                            @if ($protectionService->isUnderProtection($dominion))
+                                                <i class="ra ra-shield ra-lg text-aqua" title="Under Protection"></i>
+                                            @endif
 
-                                        @if ($guardMembershipService->isEliteGuardMember($dominion))
-                                            <i class="ra ra-heavy-shield ra-lg text-yellow" title="Elite Guard"></i>
-                                        @elseif ($guardMembershipService->isRoyalGuardMember($dominion))
-                                            <i class="ra ra-heavy-shield ra-lg text-green" title="Royal Guard"></i>
-                                        @endif
+                                            @if ($guardMembershipService->isEliteGuardMember($dominion))
+                                                <i class="ra ra-heavy-shield ra-lg text-yellow" title="Elite Guard"></i>
+                                            @elseif ($guardMembershipService->isRoyalGuardMember($dominion))
+                                                <i class="ra ra-heavy-shield ra-lg text-green" title="Royal Guard"></i>
+                                            @endif
 
-                                        <a href="{{ route('dominion.op-center.show', $dominion) }}">{{ $dominion->name }}</a>
-                                    </td>
-                                    <td class="text-center">
-                                        {{ $dominion->realm->number }}
-                                    </td>
-                                    <td class="text-center">
-                                        {{ $dominion->race->name }}
-                                    </td>
-                                    <td class="text-center" data-order="{{ $landCalculator->getTotalLand($dominion) }}" data-search="{{ $landCalculator->getTotalLand($dominion) }}">
-                                        {{ number_format($landCalculator->getTotalLand($dominion)) }}
-                                    </td>
-                                    <td class="text-center" data-order="{{ $networthCalculator->getDominionNetworth($dominion) }}" data-search="{{ $networthCalculator->getDominionNetworth($dominion) }}">
-                                        {{ number_format($networthCalculator->getDominionNetworth($dominion)) }}
-                                    </td>
-                                    <td class="hidden">
-                                        @if ($rangeCalculator->isInRange($selectedDominion, $dominion))
-                                            true
-                                        @endif
-                                    </td>
-                                </tr>
-                            @endforeach
+                                            <a href="{{ route('dominion.op-center.show', $dominion) }}">{{ $dominion->name }}</a>
+                                        </td>
+                                        <td class="text-center">
+                                            {{ $dominion->realm->number }}
+                                        </td>
+                                        <td class="text-center">
+                                            {{ $dominion->race->name }}
+                                        </td>
+                                        <td class="text-center" data-order="{{ $landCalculator->getTotalLand($dominion) }}" data-search="{{ $landCalculator->getTotalLand($dominion) }}">
+                                            {{ number_format($landCalculator->getTotalLand($dominion)) }}
+                                        </td>
+                                        <td class="text-center" data-order="{{ $networthCalculator->getDominionNetworth($dominion) }}" data-search="{{ $networthCalculator->getDominionNetworth($dominion) }}">
+                                            {{ number_format($networthCalculator->getDominionNetworth($dominion)) }}
+                                        </td>
+                                        <td class="hidden">
+                                            @if ($rangeCalculator->isInRange($selectedDominion, $dominion))
+                                                true
+                                            @endif
+                                        </td>
+                                    </tr>
+                                @endforeach
+                            @endif
                         </tbody>
                     </table>
 
@@ -143,7 +145,11 @@
                     <h3 class="box-title">Information</h3>
                 </div>
                 <div class="box-body">
-                    box body
+                    <p>Advanced search for locating dominions in other realms.</p>
+                    <p>By default, it is limited to targets that you can perform actions against due to range restrictions.</p>
+                    @if (!$selectedDominion->round->hasStarted())
+                        <p>The current round has not started. No dominions will be listed.</p>
+                    @endif
                 </div>
             </div>
         </div>

--- a/src/Http/Controllers/Dominion/RealmController.php
+++ b/src/Http/Controllers/Dominion/RealmController.php
@@ -14,7 +14,7 @@ use OpenDominion\Services\Dominion\ProtectionService;
 
 class RealmController extends AbstractDominionController
 {
-    public function getRealm(int $realmNumber = null)
+    public function getRealm(Request $request, int $realmNumber = null)
     {
         $landCalculator = app(LandCalculator::class);
         $networthCalculator = app(NetworthCalculator::class);
@@ -29,6 +29,14 @@ class RealmController extends AbstractDominionController
         }
 
         $isOwnRealm = ($realmNumber === (int)$dominion->realm->number);
+
+        if (!$round->hasStarted() && !$isOwnRealm) {
+            $request->session()->flash(
+                'alert-warning',
+                "You cannot view other realms before the round has started."
+            );
+            return redirect()->route('dominion.realm', (int)$dominion->realm->number);
+        }
 
         // Eager load some relational data to save on SQL queries down the road in NetworthCalculator and
         // ProtectionService


### PR DESCRIPTION
This has been discussed in Discord. This prevents packs from gathering information on potential opponents while some members have not yet registered. It also makes creating multiple accounts less attractive. You can still scout everyone out during protection.

- Prevents viewing other realms by redirecting back to your own realm with a warning message.
- Hides dominion search results at the template level (similar to espionage/magic/invade pages during protection).
- Replaces placeholder text in Search page info pane.