### PR TITLE
Fix additional population bugs

### DIFF
--- a/app/resources/css/skin-classic.css
+++ b/app/resources/css/skin-classic.css
@@ -350,8 +350,8 @@
 .skin-classic .navbar-nav > .notifications-menu > .dropdown-menu > li.footer > a,
 .skin-classic .navbar-nav > .messages-menu > .dropdown-menu > li.footer > a,
 .skin-classic .navbar-nav > .tasks-menu > .dropdown-menu > li.footer > a {
-    background-color: #005566;
-    border-bottom: 1px solid #675f6b;
+    background-color: #005566 !important;
+    border-bottom: 1px solid #675f6b !important;
     color: #fff !important;
 }
 .skin-classic .navbar-nav > .notifications-menu > .dropdown-menu > li .menu > li > a:hover,

--- a/src/Calculators/Dominion/MilitaryCalculator.php
+++ b/src/Calculators/Dominion/MilitaryCalculator.php
@@ -27,6 +27,9 @@ class MilitaryCalculator
     /** @var SpellCalculator */
     protected $spellCalculator;
 
+    /** @var bool */
+    protected $forTick = false;
+
     /**
      * MilitaryCalculator constructor.
      *
@@ -51,6 +54,15 @@ class MilitaryCalculator
         $this->prestigeCalculator = $prestigeCalculator;
         $this->queueService = $queueService;
         $this->spellCalculator = $spellCalculator;
+    }
+
+    /** 
+     * Toggle if this calculator should include the following hour's resources.
+     */
+    public function setForTick(bool $value)
+    {
+        $this->forTick = $value;
+        $this->queueService->setForTick($value);
     }
 
     /**

--- a/src/Calculators/Dominion/PopulationCalculator.php
+++ b/src/Calculators/Dominion/PopulationCalculator.php
@@ -33,6 +33,9 @@ class PopulationCalculator
     /** @var UnitHelper */
     protected $unitHelper;
 
+    /** @var bool */
+    protected $forTick = false;
+
     /**
      * PopulationCalculator constructor.
      *
@@ -63,6 +66,16 @@ class PopulationCalculator
         $this->queueService = $queueService;
         $this->spellCalculator = $spellCalculator;
         $this->unitHelper = $unitHelper;
+    }
+
+    /** 
+     * Toggle if this calculator should include the following hour's resources.
+     */
+    public function setForTick(bool $value)
+    {
+        $this->forTick = $value;
+        $this->militaryCalculator->setForTick($value);
+        $this->queueService->setForTick($value);
     }
 
     /**

--- a/src/Services/Dominion/Actions/ConstructActionService.php
+++ b/src/Services/Dominion/Actions/ConstructActionService.php
@@ -103,13 +103,13 @@ class ConstructActionService
         $lumberCost = $this->constructionCalculator->getTotalLumberCost($dominion, $totalBuildingsToConstruct);
 
         DB::transaction(function () use ($dominion, $data, $platinumCost, $lumberCost, $totalBuildingsToConstruct) {
+            $this->queueService->queueResources('construction', $dominion, $data);
+
             $dominion->fill([
                 'resource_platinum' => ($dominion->resource_platinum - $platinumCost),
                 'resource_lumber' => ($dominion->resource_lumber - $lumberCost),
                 'discounted_land' => max(0, $dominion->discounted_land - $totalBuildingsToConstruct),
             ])->save(['event' => HistoryService::EVENT_ACTION_CONSTRUCT]);
-
-            $this->queueService->queueResources('construction', $dominion, $data);
         });
 
         return [

--- a/src/Services/Dominion/Actions/ExploreActionService.php
+++ b/src/Services/Dominion/Actions/ExploreActionService.php
@@ -80,14 +80,14 @@ class ExploreActionService
         $newDraftees = ($dominion->military_draftees - $drafteeCost);
 
         DB::transaction(function () use ($dominion, $data, $newMorale, $newPlatinum, $newDraftees, $totalLandToExplore) {
+            $this->queueService->queueResources('exploration', $dominion, $data);
+
             $dominion->stat_total_land_explored += $totalLandToExplore;
             $dominion->fill([
                 'morale' => $newMorale,
                 'resource_platinum' => $newPlatinum,
                 'military_draftees' => $newDraftees,
             ])->save(['event' => HistoryService::EVENT_ACTION_EXPLORE]);
-
-            $this->queueService->queueResources('exploration', $dominion, $data);
         });
 
         return [

--- a/src/Services/Dominion/Actions/Military/TrainActionService.php
+++ b/src/Services/Dominion/Actions/Military/TrainActionService.php
@@ -104,13 +104,6 @@ class TrainActionService
         $newWizards = ($dominion->military_wizards - $totalCosts['wizards']);
 
         DB::transaction(function () use ($dominion, $data, $newPlatinum, $newOre, $newDraftees, $newWizards) {
-            $dominion->fill([
-                'resource_platinum' => $newPlatinum,
-                'resource_ore' => $newOre,
-                'military_draftees' => $newDraftees,
-                'military_wizards' => $newWizards,
-            ])->save(['event' => HistoryService::EVENT_ACTION_TRAIN]);
-
             // Specialists train in 9 hours
             $nineHourData = [
                 'military_unit1' => $data['military_unit1'],
@@ -120,6 +113,13 @@ class TrainActionService
 
             $this->queueService->queueResources('training', $dominion, $nineHourData, 9);
             $this->queueService->queueResources('training', $dominion, $data);
+
+            $dominion->fill([
+                'resource_platinum' => $newPlatinum,
+                'resource_ore' => $newOre,
+                'military_draftees' => $newDraftees,
+                'military_wizards' => $newWizards,
+            ])->save(['event' => HistoryService::EVENT_ACTION_TRAIN]);
         });
 
         return [

--- a/src/Services/Dominion/QueueService.php
+++ b/src/Services/Dominion/QueueService.php
@@ -26,6 +26,17 @@ use Throwable;
  */
 class QueueService
 {
+    /** @var bool */
+    protected $forTick = false;
+
+    /** 
+     * Toggle if this calculator should include the following hour's resources.
+     */
+    public function setForTick(bool $value)
+    {
+        $this->forTick = $value;
+    }
+
     /**
      * Returns the queue of specific type of a dominion.
      *
@@ -35,9 +46,14 @@ class QueueService
      */
     public function getQueue(string $source, Dominion $dominion): Collection
     {
+        $hours = 0;
+        if ($this->forTick) {
+            // don't include next hour when calculating tick
+            $hours = 1;
+        }
         return $dominion->queues
             ->where('source', $source)
-            ->where('hours', '>', 0);
+            ->where('hours', '>', $hours);
     }
 
     /**

--- a/src/Services/Dominion/TickService.php
+++ b/src/Services/Dominion/TickService.php
@@ -62,6 +62,10 @@ class TickService
         $this->productionCalculator = app(ProductionCalculator::class);
         $this->queueService = app(QueueService::class);
         $this->spellCalculator = app(SpellCalculator::class);
+
+        /* These calculators need to ignore queued resources for the following tick */
+        $this->populationCalculator->setForTick(true);
+        $this->queueService->setForTick(true);
     }
 
     /**
@@ -398,10 +402,8 @@ class TickService
 
         foreach ($incomingQueue as $row) {
             $tick->{$row->resource} += $row->amount;
-            if (strpos($row->resource, 'military_unit') === false) {
-                // Temporarily add next hour's non-military resources for accurate calculations
-                $dominion->{$row->resource} += $row->amount;
-            }
+            // Temporarily add next hour's resources for accurate calculations
+            $dominion->{$row->resource} += $row->amount;
         }
 
         // Population
@@ -410,13 +412,6 @@ class TickService
 
         $tick->peasants = $populationPeasantGrowth;
         $tick->military_draftees = $drafteesGrowthRate;
-
-        foreach ($incomingQueue as $row) {
-            if (strpos($row->resource, 'military_unit') !== false) {
-                // Temporarily add next hour's military resources for accurate calculations
-                $dominion->{$row->resource} += $row->amount;
-            }
-        }
 
         // Resources
         $tick->resource_platinum += $this->productionCalculator->getPlatinumProduction($dominion);


### PR DESCRIPTION
This fix removes some hacky stuff I did in the tickservice and replaces it with a flag on the QueueService class that will ignore queues for the following hour (hours=1) when doing the precalculateTick call in TickService. Otherwise, buildings and incoming troops will be counted twice when determining max population and weird things will happen.
 
There's also a minor change to queue resources prior to saving a dominion in the action services, which also interferes with the tick calculation. This one made you wait an additional hour before your incomings were counted (therefore offsetting the other bug and making them nearly unnoticeable in most cases).