### PR TITLE
QoL Improvements

### DIFF
--- a/app/resources/views/pages/dominion/op-center/index.blade.php
+++ b/app/resources/views/pages/dominion/op-center/index.blade.php
@@ -176,7 +176,7 @@
     <script type="text/javascript">
         (function ($) {
             $('#dominions-table').DataTable({
-                order: [[5, 'desc']],
+                order: [[4, 'desc']],
             });
             //$('#clairvoyance-table').DataTable({
             //    order: [[2, 'desc']],

--- a/app/resources/views/pages/dominion/realm.blade.php
+++ b/app/resources/views/pages/dominion/realm.blade.php
@@ -113,6 +113,7 @@
                     <p>This is the realm <strong>{{ $realm->name }} (#{{ $realm->number }})</strong>.</p>
                     <p>Its alignment is <strong>{{ $realm->alignment }}</strong>, it contains <strong>{{ $dominions->count() }}</strong> {{ str_plural('dominion', $dominions->count()) }} and its networth is <strong>{{ number_format($networthCalculator->getRealmNetworth($realm)) }}</strong>.</p>
                     {{-- todo: change this to a table? --}}
+                    <p><a href="{{ route('dominion.town-crier', [$realm->number]) }}">View Town Crier</a></p>
                     <p><a href="{{ route('dominion.realm') }}">My Realm</a></p>
                 </div>
                 @if (($prevRealm !== null) || ($nextRealm !== null))

--- a/app/resources/views/pages/dominion/search.blade.php
+++ b/app/resources/views/pages/dominion/search.blade.php
@@ -28,8 +28,8 @@
                                 <label class="col-sm-6 control-label text-right">Limit:</label>
                                 <div class="col-sm-6">
                                     <select class="form-control" name="range">
-                                        <option value="true">My Range</option>
-                                        <option value="">No Limit</option>
+                                        <option value="true">No Limit</option>
+                                        <option value="">My Range</option>
                                     </select>
                                 </div>
                             </div>

--- a/app/resources/views/pages/dominion/town-crier.blade.php
+++ b/app/resources/views/pages/dominion/town-crier.blade.php
@@ -106,11 +106,15 @@
                     @endif
                     <p>You will see only military operations, as well as death messages{{-- and important messages regarding Wonders of the World--}}. Magical and Spy attacks are not known to the Town Crier, and you will have to inquire in the council as to those types of attacks.</p>
                     <p>
-                        @if ($realm !== null)
-                            <a href="{{ route('dominion.town-crier') }}">Show All Realms</a>
-                        @else
-                            <a href="{{ route('dominion.town-crier', [$selectedDominion->realm->number]) }}">Show Only My Realm</a>
-                        @endif
+                        <label for="realm-select">Show Town Crier for:</label>
+                        <select id="realm-select" class="form-control">
+                            <option value="">All Realms</option>
+                            @for ($i=1; $i<$realmCount; $i++)
+                                <option value="{{ $i }}" {{ $realm && $realm->number == $i ? 'selected' : null }}>
+                                    #{{ $i }} {{ $selectedDominion->realm->number == $i ? '(My Realm)' : null }}
+                                </option>
+                            @endfor
+                        </select>
                     </p>
                 </div>
             </div>
@@ -118,3 +122,14 @@
 
     </div>
 @endsection
+
+@push('inline-scripts')
+    <script type="text/javascript">
+        (function ($) {
+            $('#realm-select').change(function() {
+                var selectedRealm = $(this).val();
+                window.location.href = "{!! route('dominion.town-crier') !!}/" + selectedRealm;
+            });
+        })(jQuery);
+    </script>
+@endpush

--- a/app/resources/views/pages/dominion/town-crier.blade.php
+++ b/app/resources/views/pages/dominion/town-crier.blade.php
@@ -40,25 +40,25 @@
                                                 @if ($gameEvent->source_type === \OpenDominion\Models\Dominion::class && in_array($gameEvent->source_id, $dominionIds, true))
                                                     @if ($gameEvent->data['result']['success'])
                                                         Victorious on the battlefield,
-                                                        <span class="text-aqua">{{ $gameEvent->source->name }} <a href="{{ route('dominion.town-crier', [$gameEvent->source->realm->number]) }}">(#{{ $gameEvent->source->realm->number }})</a></span>
+                                                        <span class="text-aqua">{{ $gameEvent->source->name }} <a href="{{ route('dominion.realm', [$gameEvent->source->realm->number]) }}">(#{{ $gameEvent->source->realm->number }})</a></span>
                                                         conquered
                                                         <span class="text-green text-bold">{{ number_format(array_sum($gameEvent->data['attacker']['landConquered'])) }}</span>
                                                         land from
                                                         <a href="{{ route('dominion.op-center.show', [$gameEvent->target->id]) }}"><span class="text-orange">{{ $gameEvent->target->name }}</span></a>
-                                                        <a href="{{ route('dominion.town-crier', [$gameEvent->target->realm->number]) }}">(#{{ $gameEvent->target->realm->number }})</a>.
+                                                        <a href="{{ route('dominion.realm', [$gameEvent->target->realm->number]) }}">(#{{ $gameEvent->target->realm->number }})</a>.
                                                     @else
                                                         Sadly, the forces of
-                                                        <span class="text-aqua">{{ $gameEvent->source->name }} <a href="{{ route('dominion.town-crier', [$gameEvent->source->realm->number]) }}">(#{{ $gameEvent->source->realm->number }})</a></span>
+                                                        <span class="text-aqua">{{ $gameEvent->source->name }} <a href="{{ route('dominion.realm', [$gameEvent->source->realm->number]) }}">(#{{ $gameEvent->source->realm->number }})</a></span>
                                                         were beaten back by
                                                         <a href="{{ route('dominion.op-center.show', [$gameEvent->target->id]) }}"><span class="text-orange">{{ $gameEvent->target->name }}</span></a>
-                                                        <a href="{{ route('dominion.town-crier', [$gameEvent->target->realm->number]) }}">(#{{ $gameEvent->target->realm->number }})</a>.
+                                                        <a href="{{ route('dominion.realm', [$gameEvent->target->realm->number]) }}">(#{{ $gameEvent->target->realm->number }})</a>.
                                                     @endif
                                                 @elseif ($gameEvent->target_type === \OpenDominion\Models\Dominion::class)
                                                     @if ($gameEvent->data['result']['success'])
                                                         <a href="{{ route('dominion.op-center.show', [$gameEvent->source->id]) }}"><span class="text-orange">{{ $gameEvent->source->name }}</span></a>
-                                                        <a href="{{ route('dominion.town-crier', [$gameEvent->source->realm->number]) }}">(#{{ $gameEvent->source->realm->number }})</a>
+                                                        <a href="{{ route('dominion.realm', [$gameEvent->source->realm->number]) }}">(#{{ $gameEvent->source->realm->number }})</a>
                                                         invaded
-                                                        <span class="text-aqua">{{ $gameEvent->target->name }} <a href="{{ route('dominion.town-crier', [$gameEvent->target->realm->number]) }}">(#{{ $gameEvent->target->realm->number }})</a></span>
+                                                        <span class="text-aqua">{{ $gameEvent->target->name }} <a href="{{ route('dominion.realm', [$gameEvent->target->realm->number]) }}">(#{{ $gameEvent->target->realm->number }})</a></span>
                                                         and captured
                                                         <span class="text-red text-bold">{{ number_format(array_sum($gameEvent->data['attacker']['landConquered'])) }}</span>
                                                         land.
@@ -66,10 +66,10 @@
                                                         @if ($gameEvent->source_realm_id == $selectedDominion->realm_id)
                                                             Fellow dominion
                                                         @endif
-                                                        <span class="text-aqua">{{ $gameEvent->target->name }} <a href="{{ route('dominion.town-crier', [$gameEvent->target->realm->number]) }}">(#{{ $gameEvent->target->realm->number }})</a></span>
+                                                        <span class="text-aqua">{{ $gameEvent->target->name }} <a href="{{ route('dominion.realm', [$gameEvent->target->realm->number]) }}">(#{{ $gameEvent->target->realm->number }})</a></span>
                                                         fended off an attack from
                                                         <a href="{{ route('dominion.op-center.show', [$gameEvent->source->id]) }}"><span class="text-orange">{{ $gameEvent->source->name }}</span></a>
-                                                        <a href="{{ route('dominion.town-crier', [$gameEvent->source->realm->number]) }}">(#{{ $gameEvent->source->realm->number }})</a>.
+                                                        <a href="{{ route('dominion.realm', [$gameEvent->source->realm->number]) }}">(#{{ $gameEvent->source->realm->number }})</a>.
                                                     @endif
                                                 @endif
                                             @endif

--- a/src/Http/Controllers/Dominion/SearchController.php
+++ b/src/Http/Controllers/Dominion/SearchController.php
@@ -31,7 +31,6 @@ class SearchController extends AbstractDominionController
                 'race.units.perks',
             ])
             ->where('round_id', $dominion->round_id)
-            ->where('realm_id', '!=', $dominion->realm_id)
             ->get();
 
         return view('pages.dominion.search', compact(

--- a/src/Http/Controllers/Dominion/TownCrierController.php
+++ b/src/Http/Controllers/Dominion/TownCrierController.php
@@ -28,10 +28,13 @@ class TownCrierController extends AbstractDominionController
         $gameEvents = $townCrierData['gameEvents'];
         $dominionIds = $townCrierData['dominionIds'];
 
+        $realmCount = Realm::where('round_id', $dominion->round_id)->count();
+
         return view('pages.dominion.town-crier', compact(
+            'dominionIds',
             'gameEvents',
             'realm',
-            'dominionIds'
+            'realmCount'
         ))->with('fromOpCenter', false);
     }
 }

--- a/src/Services/GameEventService.php
+++ b/src/Services/GameEventService.php
@@ -71,7 +71,7 @@ class GameEventService
         $gameEvents = GameEvent::query()
             ->where('round_id', $dominion->round_id)
             ->where('created_at', '<', $createdBefore)
-            ->where('created_at', '>', now()->subDays(7))
+            ->where('created_at', '>', now()->subDays(3))
             ->orderBy('created_at', 'desc')
             ->get();
 


### PR DESCRIPTION
A few improvements related to search and crier as discussed on discord.

- link the realm numbers in crier to realm pages (reverted)
- add a link from realm page to crier for that realm only
- limit global crier to 3 days because it's going to get really long (single realm still 7)
- fix default ordering of op center (bug)
- show own realm in search
- default to showing all results in search