### PR TITLE
Small Fixes

### DIFF
--- a/app/resources/views/pages/dominion/search.blade.php
+++ b/app/resources/views/pages/dominion/search.blade.php
@@ -28,8 +28,8 @@
                                 <label class="col-sm-6 control-label text-right">Limit:</label>
                                 <div class="col-sm-6">
                                     <select class="form-control" name="range">
-                                        <option value="true">No Limit</option>
-                                        <option value="">My Range</option>
+                                        <option value="">No Limit</option>
+                                        <option value="true">My Range</option>
                                     </select>
                                 </div>
                             </div>

--- a/src/Services/Dominion/TickService.php
+++ b/src/Services/Dominion/TickService.php
@@ -280,15 +280,13 @@ class TickService
                     continue;
                 }
 
-                foreach ($round->dominions as $dominion) {
-                    /** @var Dominion $dominion */
-                    $dominion->update([
-                        'daily_platinum' => false,
-                        'daily_land' => false,
-                    ], [
-                        'event' => 'tick',
-                    ]);
-                }
+                // toBase required to prevent ambiguous updated_at column in query
+                $round->dominions()->toBase()->update([
+                    'daily_platinum' => false,
+                    'daily_land' => false,
+                ], [
+                    'event' => 'tick',
+                ]);
             }
         });
 


### PR DESCRIPTION
- Fix an issue with the search page Limit values being flipped.
- Update daily bonuses in a single query and prevent a partial update in the event of an error.
