### PR TITLE
fix bug with slowestUnitReturnHours

### DIFF
--- a/src/Services/Dominion/Actions/InvadeActionService.php
+++ b/src/Services/Dominion/Actions/InvadeActionService.php
@@ -1344,7 +1344,7 @@ class InvadeActionService
      */
     protected function getSlowestUnitReturnHours(Dominion $dominion, array $units): int
     {
-        $hours = 12;
+        $hours = 0;
 
         foreach ($units as $slot => $amount) {
             if ($amount === 0) {
@@ -1353,9 +1353,13 @@ class InvadeActionService
 
             $hoursForUnit = $this->getUnitReturnHoursForSlot($dominion, $slot);
 
-            if ($hoursForUnit < $hours) {
+            if ($hoursForUnit > $hours) {
                 $hours = $hoursForUnit;
             }
+        }
+
+        if ($hours == 0) {
+            $hours = 12;
         }
 
         return $hours;


### PR DESCRIPTION
This was incorrectly returning the fastest units instead of slowest.

