### PR TITLE
Merge pull request #769 from internetfett/bugfix/snare_error

### DIFF
--- a/src/Services/Dominion/Actions/EspionageActionService.php
+++ b/src/Services/Dominion/Actions/EspionageActionService.php
@@ -797,6 +797,9 @@ class EspionageActionService
                 // Flat damage for Magic Snare
                 if ($attr == 'wizard_strength') {
                     $damage = 100 * $baseDamage;
+                    if ($damage > $target->wizard_strength) {
+                        $damage = (int)$target->wizard_strength;
+                    }
                 }
 
                 // Damage reduction from Docks / Harbor


### PR DESCRIPTION
Snare is the only black op to deal flat damage and there was no check to keep it from going negative and causing a 500 error.