### PR TITLE
Merge pull request #772 from internetfett/bugfix/immortal_wizards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes relevant to players in this project will be documented in th
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/). This project uses its own versioning system.
 ## [Unreleased]
+- Assassinate wizards will no longer work against undead
+- Disband spies will now add the correct number of draftees
 
 ## [0.8.0-6] - 2020-01-19
 ### Fixed

--- a/src/Services/Dominion/Actions/EspionageActionService.php
+++ b/src/Services/Dominion/Actions/EspionageActionService.php
@@ -809,7 +809,7 @@ class EspionageActionService
                 }
 
                 // Check for immortal wizards
-                if ($dominion->race->getPerkValue('immortal_wizards') != 0 && $attr == 'military_wizards') {
+                if ($target->race->getPerkValue('immortal_wizards') != 0 && $attr == 'military_wizards') {
                     $damage = 0;
                 }
 

--- a/src/Services/Dominion/Actions/SpellActionService.php
+++ b/src/Services/Dominion/Actions/SpellActionService.php
@@ -635,12 +635,16 @@ class SpellActionService
             }
             if (isset($spellInfo['increases'])) {
                 foreach ($spellInfo['increases'] as $attr) {
-                    $damage = $target->{$attr} * $baseDamage;
+                    if ($attr == 'military_draftees') {
+                        $target->{$attr} += $totalDamage;
+                    } else {
+                        $damage = $target->{$attr} * $baseDamage;
 
-                    // Damage reduction from Towers
-                    $damage *= (1 - $this->improvementCalculator->getImprovementMultiplierBonus($target, 'towers'));
+                        // Damage reduction from Towers
+                        $damage *= (1 - $this->improvementCalculator->getImprovementMultiplierBonus($target, 'towers'));
 
-                    $target->{$attr} += round($damage);
+                        $target->{$attr} += round($damage);
+                    }
                 }
             }
 


### PR DESCRIPTION
- Undead wizards can no longer be assassinated (was incorrectly protecting the source dominion instead of the target)
- Also fixes an issue where the wrong number of draftees would be added after Disband Spies.