### PR TITLE
Proper fix for Race Conditions

### DIFF
--- a/src/Models/Dominion.php
+++ b/src/Models/Dominion.php
@@ -253,7 +253,14 @@ class Dominion extends AbstractModel
     {
         $recordChanges = isset($options['event']);
 
-        if ($recordChanges) {
+        // Verify tick hasn't happened during this request
+        if ($this->exists && $this->last_tick_at != $this->fresh()->last_tick_at) {
+            throw new GameException('The Emperor is currently collecting taxes and cannot fulfill your request. Please try again.');
+        }
+
+        $saved = parent::save($options);
+
+        if ($saved && $recordChanges) {
             $dominionHistoryService = app(HistoryService::class);
             $deltaAttributes = $dominionHistoryService->getDeltaAttributes($this);
             $extraAttributes = ['action', 'defense_reduced', 'source_dominion_id', 'target_dominion_id'];
@@ -262,15 +269,6 @@ class Dominion extends AbstractModel
                     $deltaAttributes[$attr] = $options[$attr];
                 }
             }
-        }
-
-        // Verify tick hasn't happened during this request
-        if ($this->exists && $this->last_tick_at != $this->fresh()->last_tick_at) {
-            throw new GameException('The Emperor is currently collecting taxes and cannot fulfill your request. Please try again.');
-        }
-        $saved = parent::save($options);
-
-        if ($saved && $recordChanges) {
             /** @noinspection PhpUndefinedVariableInspection */
             $dominionHistoryService->record($this, $deltaAttributes, $options['event']);
         }
@@ -280,6 +278,25 @@ class Dominion extends AbstractModel
         $tickService->precalculateTick($this);
 
         return $saved;
+    }
+
+    public function getDirty()
+    {
+        $dirty = parent::getDirty();
+
+        $query = $this->newModelQuery();
+
+        $dominionHistoryService = app(HistoryService::class);
+        $deltaAttributes = $dominionHistoryService->getDeltaAttributes($this);
+
+        foreach ($deltaAttributes as $attr => $value) {
+            if (gettype($this->getAttribute($attr)) != 'boolean') {
+                $wrapped = $query->toBase()->grammar->wrap($attr);
+                $dirty[$attr] = $query->toBase()->raw("$wrapped + $value");
+            }
+        }
+
+        return $dirty;
     }
 
     /**

--- a/src/Services/Dominion/Actions/ConstructActionService.php
+++ b/src/Services/Dominion/Actions/ConstructActionService.php
@@ -107,8 +107,6 @@ class ConstructActionService
         $lumberCost = $this->constructionCalculator->getTotalLumberCost($dominion, $totalBuildingsToConstruct);
 
         DB::transaction(function () use ($dominion, $data, $platinumCost, $lumberCost, $totalBuildingsToConstruct) {
-            // Refresh in transaction to prevent race condition
-            $dominion->refresh();
             $this->queueService->queueResources('construction', $dominion, $data);
 
             $reboundAcres = max($dominion->discounted_land - $this->landCalculator->getTotalBarrenLand($dominion), 0);

--- a/src/Services/Dominion/Actions/ExploreActionService.php
+++ b/src/Services/Dominion/Actions/ExploreActionService.php
@@ -98,8 +98,6 @@ class ExploreActionService
         $drafteeCost = ($this->explorationCalculator->getDrafteeCost($dominion) * $totalLandToExplore);
 
         DB::transaction(function () use ($dominion, $data, $moraleDrop, $platinumCost, $drafteeCost, $totalLandToExplore) {
-            // Refresh in transaction to prevent race condition
-            $dominion->refresh();
             $this->queueService->queueResources('exploration', $dominion, $data);
 
             $dominion->stat_total_land_explored += $totalLandToExplore;

--- a/src/Services/Dominion/Actions/ImproveActionService.php
+++ b/src/Services/Dominion/Actions/ImproveActionService.php
@@ -52,16 +52,11 @@ class ImproveActionService
             }
 
             $points = (($amount * $worth[$resource]) * $multiplier);
-            $totalImprovements["improvement_{$improvementType}"] = $points;
+            $dominion->{"improvement_{$improvementType}"} += $points;
         }
 
-        DB::transaction(function() use ($dominion, $resource, $totalImprovements, $totalResourcesToInvest) {
-            foreach ($totalImprovements as $attr => $points) {
-                $dominion->{$attr} += $points;
-            }
-            $dominion->{'resource_' . $resource} -= $totalResourcesToInvest;
-            $dominion->save(['event' => HistoryService::EVENT_ACTION_IMPROVE]);
-        });
+        $dominion->{'resource_' . $resource} -= $totalResourcesToInvest;
+        $dominion->save(['event' => HistoryService::EVENT_ACTION_IMPROVE]);
 
         return [
             'message' => $this->getReturnMessageString($resource, $data, $totalResourcesToInvest),

--- a/src/Services/Dominion/Actions/ImproveActionService.php
+++ b/src/Services/Dominion/Actions/ImproveActionService.php
@@ -56,8 +56,6 @@ class ImproveActionService
         }
 
         DB::transaction(function() use ($dominion, $resource, $totalImprovements, $totalResourcesToInvest) {
-            // Refresh in transaction to prevent race condition
-            $dominion->refresh();
             foreach ($totalImprovements as $attr => $points) {
                 $dominion->{$attr} += $points;
             }

--- a/src/Services/Dominion/Actions/Military/TrainActionService.php
+++ b/src/Services/Dominion/Actions/Military/TrainActionService.php
@@ -110,8 +110,6 @@ class TrainActionService
         unset($data['military_unit1'], $data['military_unit2']);
 
         DB::transaction(function() use ($dominion, $totalCosts, $data, $nineHourData) {
-            // Refresh in transaction to prevent race condition
-            $dominion->refresh();
             $this->queueService->queueResources('training', $dominion, $nineHourData, 9);
             $this->queueService->queueResources('training', $dominion, $data);
             $dominion->resource_platinum -= $totalCosts['platinum'];

--- a/src/Services/Dominion/Actions/ReleaseActionService.php
+++ b/src/Services/Dominion/Actions/ReleaseActionService.php
@@ -94,24 +94,21 @@ class ReleaseActionService
             if ($amount === 0) {
                 continue;
             }
+
+            $dominion->{'military_' . $unitType} -= $amount;
+            if ($unitType === 'draftees') {
+                $dominion->peasants += $amount;
+            } else {
+                $dominion->military_draftees += $amount;
+            }
+
             $troopsReleased[$unitType] = $amount;
         }
 
-        DB::transaction(function () use ($dominion, $troopsReleased, $rawDpReleased) {
-            foreach ($troopsReleased as $unitType => $amount) {
-                $dominion->{'military_' . $unitType} -= $amount;
-                if ($unitType === 'draftees') {
-                    $dominion->peasants += $amount;
-                } else {
-                    $dominion->military_draftees += $amount;
-                }
-            }
-
-            $dominion->save([
-                'event' => HistoryService::EVENT_ACTION_RELEASE,
-                'defense_reduced' => $rawDpReleased
-            ]);
-        });
+        $dominion->save([
+            'event' => HistoryService::EVENT_ACTION_RELEASE,
+            'defense_reduced' => $rawDpReleased
+        ]);
 
         return [
             'message' => $this->getReturnMessageString($dominion, $troopsReleased),


### PR DESCRIPTION
- Overriding Dominion::getDirty changes the update query to increment/decrement the current values instead of just setting it to something that was calculated beforehand
- Manually updated dominion_queues query to increment queued resource amount
- Removes nested transaction present in queueResources that prevented updating queues even after other resources were spent
- Allows precalculateTick call on save even when no attributes were changed (accounting for changes to active_spells table)