### PR TITLE
Updated PR for administrative suspension

### DIFF
--- a/app/database/migrations/2020_05_05_020705_add_locked_at_to_dominions_table.php
+++ b/app/database/migrations/2020_05_05_020705_add_locked_at_to_dominions_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddLockedAtToDominionsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('dominions', function (Blueprint $table) {
+            $table->timestamp('locked_at')->after('last_tick_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('dominions', function (Blueprint $table) {
+            $table->dropColumn('locked_at');
+        });
+    }
+}

--- a/app/resources/views/layouts/topnav.blade.php
+++ b/app/resources/views/layouts/topnav.blade.php
@@ -59,6 +59,7 @@
                         <li class="{{ Route::is('valhalla.*') ? 'active' : null }}"><a href="{{ route('valhalla.index') }}">Valhalla</a></li>
                         <li class="{{ Route::is('scribes.*') ? 'active' : null }}"><a href="{{ route('scribes.races') }}">Scribes</a></li>
                         @include('partials.wiki-nav')
+                        <li class="{{ Route::is('user-agreement') ? 'active' : null }}"><a href="{{ route('user-agreement') }}">Rules</a></li>
                         @auth
                             @if ($selectorService->hasUserSelectedDominion())
                                 <li><a href="{{ route('dominion.status') }}"><b>Play</b></a></li>

--- a/app/resources/views/pages/dominion/realm.blade.php
+++ b/app/resources/views/pages/dominion/realm.blade.php
@@ -86,6 +86,10 @@
                                                     <span class="label label-info">Bot</span>
                                                 @endif
                                             @endif
+
+                                            @if ($dominion->locked_at !== null)
+                                                <span class="label label-danger">Locked</span>
+                                            @endif
                                         </td>
                                         @if ($isOwnRealm && $selectedDominion->pack !== null)
                                             @if (($dominion->pack !== null) && ($dominion->pack->id === $selectedDominion->pack->id))

--- a/app/resources/views/pages/dominion/search.blade.php
+++ b/app/resources/views/pages/dominion/search.blade.php
@@ -108,6 +108,9 @@
                                                         <i class="ra ra-heavy-shield ra-lg text-green" title="Royal Guard"></i>
                                                     @endif
                                                     <a href="{{ route('dominion.op-center.show', $dominion) }}">{{ $dominion->name }}</a>
+                                                    @if ($dominion->locked_at !== null)
+                                                        <span class="label label-danger">Locked</span>
+                                                    @endif
                                                 </td>
                                                 <td class="text-center">
                                                     <a href="{{ route('dominion.realm', [$dominion->realm->number]) }}">

--- a/app/resources/views/pages/round/register.blade.php
+++ b/app/resources/views/pages/round/register.blade.php
@@ -153,20 +153,40 @@
                 <div class="form-group">
                     <label class="col-sm-3 control-label">Rules</label>
                     <div class="col-sm-9">
-                        <ul>
-                            <li>One account per player and no account sharing.</li>
-                            <li>No actions are to be performed via scripting/automation of any kind.</li>
-                        </ul>
+                        <div class="checkbox">
+                            <label>
+                                <input type="checkbox" id="agreement_rules" name="agreement_rules" />
+                                I will adhere to the rules described in the OpenDominion <a href="#" data-toggle="modal" data-target="#user-agreement">User Agreement</a>.
+                            </label>
+                        </div>
                     </div>
                 </div>
 
             </div>
 
-            <div class="box-footer text-right">
-                <button type="submit" class="btn btn-primary">Register</button>
+            <div class="box-footer">
+                <button type="submit" class="btn btn-primary" id="register_submit" disabled>Register</button>
             </div>
 
         </form>
+    </div>
+
+    <!-- Modal -->
+    <div class="modal fade" id="user-agreement" tabindex="-1" role="dialog" aria-labelledby="user-agreement-label">
+        <div class="modal-dialog modal-lg" role="document">
+            <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title" id="user-agreement-label">User Agreement</h4>
+            </div>
+            <div class="modal-body">
+                @include('partials.user-agreement')
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+            </div>
+            </div>
+        </div>
     </div>
 @endsection
 
@@ -197,6 +217,14 @@
             realmTypeEl.on('change', updatePackInputs);
 
             updatePackInputs();
+
+            $('#agreement_rules').change(function() {
+                if ($(this).is(":checked")) {
+                    $('#register_submit').prop('disabled', false);
+                } else {
+                    $('#register_submit').prop('disabled', true);
+                }
+            });
         })(jQuery);
     </script>
 @endpush

--- a/app/resources/views/pages/user-agreement.blade.php
+++ b/app/resources/views/pages/user-agreement.blade.php
@@ -1,0 +1,18 @@
+@extends('layouts.topnav')
+
+@section('content')
+    <div class="row">
+        <div class="col-sm-12">
+            <div class="box box-primary">
+                <div class="box-header with-border">
+                    <h3 class="box-title">
+                        User Agreement
+                    </h3>
+                </div>
+                <div class="box-body">
+                    @include('partials.user-agreement')
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/app/resources/views/partials/alerts.blade.php
+++ b/app/resources/views/partials/alerts.blade.php
@@ -1,8 +1,12 @@
 @if (isset($selectedDominion) && !Route::is('home'))
     @if ($selectedDominion->isLocked())
         <div class="alert alert-warning">
-            <p><i class="icon fa fa-warning"></i> This dominion is <strong>locked</strong> due to the round having ended. No actions can be performed and no ticks will be processed.</p>
-            <p>Go to your <a href="{{ route('dashboard') }}">dashboard</a> to check if new rounds are open to play.</p>
+            @if ($selectedDominion->locked_at !== null)
+                <p><i class="icon fa fa-warning"></i> This dominion is <strong>locked</strong> due to a rules violation. No actions can be performed and no ticks will be processed.</p>
+            @else
+                <p><i class="icon fa fa-warning"></i> This dominion is <strong>locked</strong> due to the round having ended. No actions can be performed and no ticks will be processed.</p>
+                <p>Go to your <a href="{{ route('dashboard') }}">dashboard</a> to check if new rounds are open to play.</p>
+            @endif
         </div>
     @endif
 

--- a/app/resources/views/partials/user-agreement.blade.php
+++ b/app/resources/views/partials/user-agreement.blade.php
@@ -1,0 +1,61 @@
+<ol style="list-style: decimal;">
+    <li>General</li>
+    <ol style="list-style: lower-alpha;">
+        <li>By playing OpenDominion, you agree to follow these rules at all times.</li>
+        <li>The rules apply to all players at all times and everywhere.</li>
+        <li>The administrators are the sole arbiter in OpenDominion.</li>
+    </ol>
+    <li>Accounts</li>
+    <ol style="list-style: lower-alpha;">
+        <li>Accounts are personal.</li>
+        <ol style="list-style: lower-roman;">
+            <li>One person per account: only one person is permitted to make use of an account.</li>
+            <li>One account per person: each person is permitted to have only one account.</li>
+        </ol>
+        <li>If your account is suspended or banned, you are not permitted to open a new account or use another account.</li>
+        <li>If you have forgotten your password, use the password reset function. If you do not have access to your email account, contact an administrator on Discord or via help@opendominion.net.</li>
+        <li>Accounts must be kept secure.</li>
+        <ol style="list-style: lower-roman;">
+            <li>You are responsible for ensuring that no one else can access your account. We recommend that you use a unique, secure password and do not reveal it to anyone.</li>
+            <li>Log out from your account after you are done or when you are leaving the device, especially when using a shared device.</li>
+            <li>Protect your device.</li>
+        </ol>
+        <li>Account username, ruler name, and dominion names must not be offensive, misleading, or otherwise cause or risk to cause damage to the game.</li>
+    </ol>
+    <li>Gameplay</li>
+    <ol style="list-style: lower-alpha;">
+        <li>Your realm is your team.</li>
+        <li>You must always act in the best interest of your realm, except where such action violates any of the other rules.</li>
+        <li>You must not in any way cooperate with another realm or dominions in other realms, such as Non-Aggression Pacts ("NAP") or alliances.</li>
+        <ol style="list-style: lower-roman;">
+            <li>An "alliance" is defined as intentionally cooperating and/or planning actions with a player or players from another realm in any way, including if it benefits both realms.</li>
+        </ol>
+        <li>You must not in any way intentionally take any action which solely benefits another realm or a dominion in another realm, whether directly or indirectly.</li>
+        <li>You must not share information about any dominion with anyone except with players in your own realm.</li>
+        <li>You must at all times refrain from using excessive profanity or abusive, offensive language. Banter and smack talk are allowed; just keep it mostly civil.</li>
+        <li>You must not use any scripts, bots, automation software, hacks or other means to perform in-game actions with your dominion at any time.</li>
+        <li>You must not exploit any bugs in the game.</li>
+        <ol style="list-style: lower-roman;">
+            <li>A bug is a feature, mechanic, logic, or other part of the game which is not working as intended or not working at all.</li>
+            <li>You are reasonably expected to know how the game works and we will not accept ignorance as an excuse for exploiting a bug.</li>
+            <li>If you find a bug, please report it immediately in Discord or by contacting an administrator.</li>
+        </ol>
+        <li>If you are negatively impacted by a bug and cannot be reasonably expected to have known about the bug, you may be compensated appropriately, at our sole discretion.</li>
+    </ol>
+    <li>Investigation and Penalty</li>
+    <ol style="list-style: lower-alpha;">
+        <li>If we have reason to believe that you are or have been involved in actions which breach any of these rules, your account may be investigated. While your account is being investigated, it may be suspended during which time you will not be able to log in.</li>
+        <ol style="list-style: lower-roman;">
+            <li>If sufficient evidence of breach of rules cannot be found, your account will be unsuspended and you may, at our discretion, be given resources as compensation for the time during which your dominion was suspended.</li>
+            <li>If we determine that you have broken the rules, you will receive a penalty. The penalty shall be both adequate and proportionate and is at our sole discretion.</li>
+        </ol>
+        <li>The following penalties may be used:</li>
+        <ol style="list-style: lower-roman;">
+            <li>Suspension (temporary): your dominion is suspended and cannot be used for a period of time. You may resume playing once the suspension is lifted.</li>
+            <li>Suspension (permanent): your dominion is suspended for the remainder of the round.</li>
+            <li>Adjustment: you may have resources, military units, land, prestige, spells, and other parts of your dominion adjusted in your dominion if they are found to be obtained through actions which violate the rules.</li>
+            <li>Name change: if your ruler name or dominion name is found to breach the rules, it may be changed.</li>
+        </ol>
+        <li>If you have been negatively impacted by other players breaching the rules and this can be substantiated during the investigation, you may receive an adequate and proportionate compensation, at our sole discretion.</li>
+    </ol>
+</ol>

--- a/app/routes/web.php
+++ b/app/routes/web.php
@@ -5,6 +5,7 @@ use Spatie\Honeypot\ProtectAgainstSpam;
 
 /** @var Router $router */
 $router->get('/')->uses('HomeController@getIndex')->name('home');
+$router->get('user-agreement')->uses('HomeController@getUserAgreement')->name('user-agreement');
 
 // Authentication
 

--- a/src/Calculators/Dominion/RangeCalculator.php
+++ b/src/Calculators/Dominion/RangeCalculator.php
@@ -173,7 +173,7 @@ class RangeCalculator
     public function getDominionsInRange(Dominion $self): Collection
     {
         // todo: this doesn't belong here since it touches the db. Move to RangeService?
-        return $self->round->dominions()
+        return $self->round->activeDominions()
             ->with(['realm', 'round'])
             ->get()
             ->filter(function ($dominion) use ($self) {

--- a/src/Http/Controllers/Dominion/CouncilController.php
+++ b/src/Http/Controllers/Dominion/CouncilController.php
@@ -17,8 +17,12 @@ class CouncilController extends AbstractDominionController
     {
         $dominion = $this->getSelectedDominion();
         $this->updateDominionCouncilLastRead($dominion);
-        $councilService = app(CouncilService::class);
 
+        if ($dominion->locked_at !== null) {
+            return redirect()->back()->withErrors(['Locked dominions are not allowed access to the council.']);
+        }
+
+        $councilService = app(CouncilService::class);
         $threads = $councilService->getThreads($dominion->realm);
 
         return view('pages.dominion.council.index', [
@@ -80,6 +84,10 @@ class CouncilController extends AbstractDominionController
 
         $dominion = $this->getSelectedDominion();
         $this->updateDominionCouncilLastRead($dominion);
+
+        if ($dominion->locked_at !== null) {
+            return redirect()->back()->withErrors(['Locked dominions are not allowed access to the council.']);
+        }
 
         $thread->load('dominion.realm', 'posts.dominion.realm');
 

--- a/src/Http/Controllers/Dominion/OpCenterController.php
+++ b/src/Http/Controllers/Dominion/OpCenterController.php
@@ -53,6 +53,10 @@ class OpCenterController extends AbstractDominionController
 
     public function getDominion(Dominion $dominion)
     {
+        if ($this->getSelectedDominion()->round_id != $dominion->round_id) {
+            return redirect()->route('dominion.op-center');
+        }
+
         $infoOpService = app(InfoOpService::class);
 
         $latestInfoOps = $this->getSelectedDominion()->realm->infoOps()
@@ -79,6 +83,10 @@ class OpCenterController extends AbstractDominionController
 
     public function getDominionArchive(Dominion $dominion, string $type)
     {
+        if ($this->getSelectedDominion()->round_id != $dominion->round_id) {
+            return redirect()->route('dominion.op-center');
+        }
+
         $resultsPerPage = 10;
         $valid_types = ['clear_sight', 'vision', 'revelation', 'barracks_spy', 'castle_spy', 'survey_dominion', 'land_spy'];
         $infoOpService = app(InfoOpService::class);

--- a/src/Http/Controllers/HomeController.php
+++ b/src/Http/Controllers/HomeController.php
@@ -57,4 +57,9 @@ class HomeController extends AbstractController
             'currentRankings' => $currentRankings
         ]);
     }
+
+    public function getUserAgreement()
+    {
+        return view('pages.user-agreement');
+    }
 }

--- a/src/Models/Dominion.php
+++ b/src/Models/Dominion.php
@@ -166,7 +166,10 @@ class Dominion extends AbstractModel
         'council_last_read' => 'datetime',
         'forum_last_read' => 'datetime',
         'royal_guard_active_at' => 'datetime',
-        'eltie_guard_active_at' => 'datetime',
+        'elite_guard_active_at' => 'datetime',
+        'last_tick_at' => 'datetime',
+        'locked_at' => 'datetime',
+        'protection_ticks_remaining' => 'integer',
     ];
 
     // Transient properties
@@ -338,7 +341,7 @@ class Dominion extends AbstractModel
     }
 
     /**
-     * Returns whether this Dominion is locked due to the round having ended.
+     * Returns whether this Dominion is locked due to the round having ended or administrative action.
      *
      * Locked Dominions cannot perform actions and are read-only.
      *
@@ -346,7 +349,7 @@ class Dominion extends AbstractModel
      */
     public function isLocked()
     {
-        return (now() >= $this->round->end_date);
+        return (now() >= $this->round->end_date) || ($this->locked_at !== null);
     }
 
     /**

--- a/src/Models/Round.php
+++ b/src/Models/Round.php
@@ -51,6 +51,11 @@ class Round extends AbstractModel
         return $this->hasManyThrough(Dominion::class, Realm::class);
     }
 
+    public function activeDominions()
+    {
+        return $this->dominions()->where('locked_at', null);
+    }
+
     public function gameEvents()
     {
         return $this->hasMany(GameEvent::class);

--- a/src/Services/Dominion/Actions/DailyBonusesActionService.php
+++ b/src/Services/Dominion/Actions/DailyBonusesActionService.php
@@ -20,6 +20,8 @@ class DailyBonusesActionService
      */
     public function claimPlatinum(Dominion $dominion): array
     {
+        $this->guardLockedDominion($dominion);
+
         if ($dominion->daily_platinum) {
             throw new GameException('You already claimed your platinum bonus for today.');
         }
@@ -49,6 +51,8 @@ class DailyBonusesActionService
      */
     public function claimLand(Dominion $dominion): array
     {
+        $this->guardLockedDominion($dominion);
+
         if ($dominion->daily_land) {
             throw new GameException('You already claimed your land bonus for today.');
         }

--- a/src/Services/Dominion/Actions/EspionageActionService.php
+++ b/src/Services/Dominion/Actions/EspionageActionService.php
@@ -113,6 +113,7 @@ class EspionageActionService
     public function performOperation(Dominion $dominion, string $operationKey, Dominion $target): array
     {
         $this->guardLockedDominion($dominion);
+        $this->guardLockedDominion($target);
 
         $operationInfo = $this->espionageHelper->getOperationInfo($operationKey);
 

--- a/src/Services/Dominion/Actions/GovernmentActionService.php
+++ b/src/Services/Dominion/Actions/GovernmentActionService.php
@@ -44,6 +44,8 @@ class GovernmentActionService
      */
     public function voteForMonarch(Dominion $dominion, ?int $monarch_id)
     {
+        $this->guardLockedDominion($dominion);
+
         $monarch = Dominion::find($monarch_id);
         if ($monarch == null) {
             throw new RuntimeException('Dominion not found.');
@@ -67,6 +69,8 @@ class GovernmentActionService
      */
     public function updateRealm(Dominion $dominion, ?string $motd, ?string $name)
     {
+        $this->guardLockedDominion($dominion);
+
         if (!$dominion->isMonarch()) {
             throw new GameException('Only the monarch can make changes to their realm.');
         }
@@ -99,6 +103,8 @@ class GovernmentActionService
      */
     public function declareWar(Dominion $dominion, int $realm_number)
     {
+        $this->guardLockedDominion($dominion);
+
         $target = Realm::where(['round_id'=>$dominion->round_id, 'number'=>$realm_number])->first();
         if ($target == null || $dominion->realm->round_id != $target->round_id) {
             throw new RuntimeException('Realm not found.');
@@ -163,6 +169,8 @@ class GovernmentActionService
      */
     public function cancelWar(Dominion $dominion)
     {
+        $this->guardLockedDominion($dominion);
+
         if (!$dominion->isMonarch()) {
             throw new GameException('Only the monarch can declare war.');
         }

--- a/src/Services/Dominion/Actions/GuardMembershipActionService.php
+++ b/src/Services/Dominion/Actions/GuardMembershipActionService.php
@@ -33,6 +33,8 @@ class GuardMembershipActionService
      */
     public function joinRoyalGuard(Dominion $dominion): array
     {
+        $this->guardLockedDominion($dominion);
+
         if (!$this->guardMembershipService->canJoinGuards($dominion)) {
             throw new GameException('You cannot join the Emperor\'s Royal Guard for the first five days of the round.');
         }
@@ -64,6 +66,8 @@ class GuardMembershipActionService
      */
     public function joinEliteGuard(Dominion $dominion): array
     {
+        $this->guardLockedDominion($dominion);
+
         // todo: cannot join for first 5 days
         if (!$this->guardMembershipService->isRoyalGuardMember($dominion)) {
             throw new GameException('You must already be a member of the Emperor\'s Royal Guard.');
@@ -96,6 +100,8 @@ class GuardMembershipActionService
      */
     public function leaveRoyalGuard(Dominion $dominion): array
     {
+        $this->guardLockedDominion($dominion);
+
         if ($this->guardMembershipService->getHoursBeforeLeaveRoyalGuard($dominion)) {
             throw new GameException('You cannot leave the Emperor\'s Royal Guard for 48 hours after joining.');
         }
@@ -135,6 +141,8 @@ class GuardMembershipActionService
      */
     public function leaveEliteGuard(Dominion $dominion): array
     {
+        $this->guardLockedDominion($dominion);
+
         if ($this->guardMembershipService->getHoursBeforeLeaveEliteGuard($dominion)) {
             throw new GameException('You cannot leave the Emperor\'s Elite Guard for 48 hours after joining.');
         }

--- a/src/Services/Dominion/Actions/InvadeActionService.php
+++ b/src/Services/Dominion/Actions/InvadeActionService.php
@@ -173,10 +173,10 @@ class InvadeActionService
      */
     public function invade(Dominion $dominion, Dominion $target, array $units): array
     {
-        DB::transaction(function () use ($dominion, $target, $units) {
-            // Checks
-            $this->guardLockedDominion($dominion);
+        $this->guardLockedDominion($dominion);
+        $this->guardLockedDominion($target);
 
+        DB::transaction(function () use ($dominion, $target, $units) {
             if ($dominion->round->hasOffensiveActionsDisabled()) {
                 throw new GameException('Invasions have been disabled for the remainder of the round.');
             }

--- a/src/Services/Dominion/Actions/SpellActionService.php
+++ b/src/Services/Dominion/Actions/SpellActionService.php
@@ -97,6 +97,9 @@ class SpellActionService
     public function castSpell(Dominion $dominion, string $spellKey, ?Dominion $target = null): array
     {
         $this->guardLockedDominion($dominion);
+        if ($target !== null) {
+            $this->guardLockedDominion($target);
+        }
 
         $spellInfo = $this->spellHelper->getSpellInfo($spellKey, $dominion->race);
 

--- a/src/Services/Dominion/HistoryService.php
+++ b/src/Services/Dominion/HistoryService.php
@@ -156,6 +156,7 @@ class HistoryService
                 'royal_guard_active_at',
                 'elite_guard_active_at',
                 'last_tick_at',
+                'locked_at',
                 'monarchy_vote_for_dominion_id',
             ])->keys()->toArray();
     }

--- a/src/Traits/DominionGuardsTrait.php
+++ b/src/Traits/DominionGuardsTrait.php
@@ -2,8 +2,8 @@
 
 namespace OpenDominion\Traits;
 
+use OpenDominion\Exceptions\GameException;
 use OpenDominion\Models\Dominion;
-use RuntimeException;
 
 trait DominionGuardsTrait
 {
@@ -16,7 +16,7 @@ trait DominionGuardsTrait
     public function guardLockedDominion(Dominion $dominion): void
     {
         if ($dominion->isLocked()) {
-            throw new RuntimeException("Dominion {$dominion->name} is locked");
+            throw new GameException("Dominion {$dominion->name} is locked");
         }
     }
 }


### PR DESCRIPTION
An administrator can lock a dominion by setting the locked_at attribute. This will prevent any actions performed by or against the dominion via DominionGuardsTrait, suspends hourly ticks, prevents viewing Council, and shows a 'Locked' badge beside the dominion name on the Realm/Search pages.

A subsequent commit will add a user agreement to the round registration form.